### PR TITLE
Mandrel directory naming

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -43,8 +43,10 @@ jobs:
         ${{ github.workspace }}/mandrel/bin/native-image HelloStrict
         ./hellostrict > native.txt
         diff java.txt native.txt
+    - name: Archive Mandrel build
+      run: tar czf ${{ github.workspace }}/mandrel.tar.gz -C ${{ github.workspace }} mandrel
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v1
       with:
         name: mandrel-java11-linux-amd64-test-build
-        path: ${{ github.workspace }}/mandrel
+        path: ${{ github.workspace }}/mandrel.tar.gz

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -20,9 +20,9 @@ jobs:
       run: AT='' make build-image
     - name: buildJDK
       run: |
-        docker run --name=mandrel-builder -w /root --entrypoint "/bin/bash" -e VERBOSE=true mandrel-packaging --login ./buildJDK.sh
+        docker run --name=mandrel-builder -w /root --entrypoint "/bin/bash" -e VERBOSE=true -e MANDREL_HOME=/opt/mandrel mandrel-packaging --login ./buildJDK.sh
         docker ps -a
-        docker cp mandrel-builder:/opt/mandrelJDK/ ${{ github.workspace }}/mandrel/
+        docker cp mandrel-builder:/opt/mandrel/ ${{ github.workspace }}/mandrel/
     - name: Smoke tests
       run: |
         ${{ github.workspace }}/mandrel/bin/native-image --version

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -62,11 +62,15 @@ jobs:
     - name: Build Mandrel JDK
       run: |
         ./buildJDK.sh
-        mv mandrel-java11-linux-amd64-10.9.8.7.tar.gz mandrel-java11-linux-amd64.tar.gz
+        export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
+        export ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java11-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
-        /opt/mandrelJDK/bin/native-image --version
-        /opt/mandrelJDK/bin/native-image --version | grep "${MANDREL_VERSION}"
+        export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
+        export MANDREL_HOME=${PWD}/mandrel-java11-${MANDREL_VERSION_UNTIL_SPACE}
+        ${MANDREL_HOME}/bin/native-image --version
+        ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
         public class HelloStrict {
             public static void main(String[] args) {
@@ -79,9 +83,9 @@ jobs:
             }
         }
         " > HelloStrict.java
-        /opt/mandrelJDK/bin/javac HelloStrict.java
-        /opt/mandrelJDK/bin/java HelloStrict > java.txt
-        /opt/mandrelJDK/bin/native-image HelloStrict
+        ${MANDREL_HOME}/bin/javac HelloStrict.java
+        ${MANDREL_HOME}/bin/java HelloStrict > java.txt
+        ${MANDREL_HOME}/bin/native-image HelloStrict
         ./hellostrict > native.txt
         diff java.txt native.txt
     - name: Upload Mandrel build

--- a/buildJDK.sh
+++ b/buildJDK.sh
@@ -13,7 +13,7 @@ MANDREL_REPO=${MANDREL_REPO:-/tmp/mandrel}
 MAVEN_REPO=${MAVEN_REPO:-~/.m2/repository}
 MANDREL_VERSION=${MANDREL_VERSION:-$((git -C ${MANDREL_REPO} describe 2>/dev/null || git -C ${MANDREL_REPO} rev-parse --short HEAD) | sed 's/mandrel-//')}
 MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-MANDREL_HOME=${MANDREL_HOME:-/opt/mandrel-java${JAVA_MAJOR}-${MANDREL_VERSION_UNTIL_SPACE}}
+MANDREL_HOME=${MANDREL_HOME:-${PWD}/mandrel-java${JAVA_MAJOR}-${MANDREL_VERSION_UNTIL_SPACE}}
 MAVEN_ARTIFACTS_VERSION="${MANDREL_VERSION_UNTIL_SPACE}.redhat-00001"
 
 if [[ "${SKIP_CLEAN}" == "true" ]]; then

--- a/buildJDK.sh
+++ b/buildJDK.sh
@@ -8,21 +8,21 @@ fi
 
 MX_HOME=${MX_HOME:-/opt/mx}
 JAVA_HOME=${JAVA_HOME:-/opt/jdk}
+JAVA_MAJOR=$(${JAVA_HOME}/bin/java --version | awk -F'[. ]' '/openjdk / {print $2}')
 MANDREL_REPO=${MANDREL_REPO:-/tmp/mandrel}
-MANDREL_HOME=${MANDREL_HOME:-/opt/mandrelJDK}
 MAVEN_REPO=${MAVEN_REPO:-~/.m2/repository}
+MANDREL_VERSION=${MANDREL_VERSION:-$((git -C ${MANDREL_REPO} describe 2>/dev/null || git -C ${MANDREL_REPO} rev-parse --short HEAD) | sed 's/mandrel-//')}
+MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
+MANDREL_HOME=${MANDREL_HOME:-/opt/mandrel-java${JAVA_MAJOR}-${MANDREL_VERSION_UNTIL_SPACE}}
+MAVEN_ARTIFACTS_VERSION="${MANDREL_VERSION_UNTIL_SPACE}.redhat-00001"
+
 if [[ "${SKIP_CLEAN}" == "true" ]]; then
     SKIP_CLEAN_FLAG=--skipClean
 fi
 # tarxz or tar.gz
 TAR_SUFFIX=${TAR_SUFFIX:-tar.gz}
 
-pushd ${MANDREL_REPO}/substratevm
-MANDREL_VERSION=${MANDREL_VERSION:-$((git describe 2>/dev/null || git rev-parse --short HEAD) | sed 's/mandrel-//')}
-popd
-MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-MAVEN_ARTIFACTS_VERSION="${MANDREL_VERSION_UNTIL_SPACE}.redhat-00001"
-ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.${TAR_SUFFIX}"
+ARCHIVE_NAME="mandrel-java${JAVA_MAJOR}-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.${TAR_SUFFIX}"
 
 ### Build Mandrel
 ## JVM bits


### PR DESCRIPTION
Graal releases contain a directory named graalvm-ce-java11-20.1.0
while mandrel contains mandrelJDK making it impossible to unarchive
multiple versions at the same directory.

$ tar tf graalvm-ce-java11-linux-amd64-20.1.0.tar.gz | head -n 1
graalvm-ce-java11-20.1.0/GRAALVM-README.md

$ tar tf mandrel-java11-linux-amd64-20.1.0.0.Alpha1.tar.gz | head -n 1
mandrelJDK/

This commit takes a similar approach, naming mandrel directories like
mandrel-java11-20.1.0.0.Alpha1