### PR TITLE
Fix ansible playbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PLAYBOOK ?= ansible/playbook.yml
 PLAYBOOK_CONF ?= mandrel20.1-openjdk
 DOCKER_RUN_OPTIONS ?=
 AT ?= @
+$(AT)VERBOSE = -v
 
 default:
 	make build-image
@@ -16,7 +17,7 @@ build-image:
 	$(AT)$(DOCKER) stop $(BOOT_CONTAINER) 2>&1 > /dev/null || true
 	$(AT)$(DOCKER) rm $(BOOT_CONTAINER) 2>&1 > /dev/null || true
 	$(AT)$(DOCKER) run --name=$(BOOT_CONTAINER) -itd fedora:32
-	$(AT)ansible-playbook -i $(BOOT_CONTAINER), -c $(DOCKER) $(PLAYBOOK) -e configuration=$(PLAYBOOK_CONF)
+	$(AT)ansible-playbook $(VERBOSE) -i $(BOOT_CONTAINER), -c $(DOCKER) $(PLAYBOOK) -e configuration=$(PLAYBOOK_CONF)
 	$(AT)$(DOCKER) commit --author "Mandrel Packaging" $(BOOT_CONTAINER) $(IMAGE_NAME)
 	$(AT)$(DOCKER) stop $(BOOT_CONTAINER)
 	$(AT)$(DOCKER) rm $(BOOT_CONTAINER)

--- a/ansible/roles/mx/tasks/main.yml
+++ b/ansible/roles/mx/tasks/main.yml
@@ -32,7 +32,9 @@
     extra_opts:
     - --strip-components=1
 
-- name: Add mx to $PATH
+- name: Add mx to $PATH and set MX_PYTHON
   copy:
     dest: /etc/profile.d/mx.sh
-    content: "export PATH={{ mx_path }}:$PATH"
+    content: |
+      export PATH={{ mx_path }}:$PATH
+      export MX_PYTHON=python3


### PR DESCRIPTION
fedora:32 no longer provides the python symlink so we need to
explicitly set MX_PYTHON so that mx will use python3 instead of python