### PR TITLE
Add dependencies for building native-image-agent library

### DIFF
--- a/build.java
+++ b/build.java
@@ -103,6 +103,10 @@ public class build
                 nativeImage);
         Files.createSymbolicLink(mandrelHome.resolve(Path.of("bin", "native-image")), Path.of("..", "lib", "svm", "bin", "native-image"));
 
+        // logger.info("Copy macros!");
+        fs.copyDirectory(mandrelRepo.resolve(Path.of("sdk", "mxbuild", "native-image.properties", "native-image-agent-library")),
+                mandrelHome.resolve(Path.of("lib", "svm", "macros", "native-image-agent-library")));
+
         // Patch native image
         patchNativeImageLauncher(nativeImage, options.mandrelVersion);
 
@@ -530,12 +534,12 @@ class Mx
         Pattern.compile("\"version\"\\s*:\\s*\"([0-9.]*)\"");
 
     static final List<BuildArgs> BUILD_JAVA_STEPS = List.of(
-            BuildArgs.of("--no-native", "--dependencies", "SVM,SVM_DRIVER")
+            BuildArgs.of("--no-native", "--dependencies", "SVM,SVM_DRIVER,SVM_AGENT")
     );
 
     static final List<BuildArgs> BUILD_NATIVE_STEPS = List.of(
             BuildArgs.of("--projects", "com.oracle.svm.native.libchelper,com.oracle.svm.native.jvm.posix")
-            , BuildArgs.of("--only", "native-image.image-bash")
+            , BuildArgs.of("--only", "native-image.image-bash,native-image-agent-library_native-image.properties")
     );
 
     static void build(
@@ -602,6 +606,8 @@ class Mx
                     , "--trust-http"
                     , "--java-home"
                     , javaHome.get().toString()
+                    , "--native-images=lib:native-image-agent"
+                    , "--exclude-components=nju"
                     , "build"
                 )
                 , buildArgs.args
@@ -868,10 +874,13 @@ class Maven
         "graal-sdk"
         , "svm"
         , "pointsto"
+        , "library-support"
         , "truffle-api"
         , "compiler"
         , "objectfile"
         , "svm-driver"
+        , "jvmti-agent-base"
+        , "svm-agent"
     );
 
     static final String INSTALL_FILE_VERSION = "2.4";
@@ -892,30 +901,39 @@ class Maven
         "graal-sdk", "org.graalvm.sdk"
         , "svm", "org.graalvm.nativeimage"
         , "pointsto", "org.graalvm.nativeimage"
+        , "library-support", "org.graalvm.nativeimage"
         , "truffle-api", "org.graalvm.truffle"
         , "compiler", "org.graalvm.compiler"
         , "objectfile", "org.graalvm.nativeimage"
         , "svm-driver", "org.graalvm.nativeimage"
+        , "jvmti-agent-base", "org.graalvm.nativeimage"
+        , "svm-agent", "org.graalvm.nativeimage"
     );
 
     static final Map<String, Path> DISTS_PATHS = Map.of(
         "graal-sdk", Path.of("sdk", "mxbuild", "dists", "jdk11", "graal-sdk")
         , "svm", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm")
         , "pointsto", Path.of("substratevm", "mxbuild", "dists", "jdk11", "pointsto")
+        , "library-support", Path.of("substratevm", "mxbuild", "dists", "jdk1.8", "library-support")
         , "truffle-api", Path.of("truffle", "mxbuild", "dists", "jdk11", "truffle-api")
         , "compiler", Path.of("compiler", "mxbuild", "dists", "jdk11", "graal")
         , "objectfile", Path.of("substratevm", "mxbuild", "dists", "jdk1.8", "objectfile")
         , "svm-driver", Path.of("substratevm", "mxbuild", "dists", "jdk1.8", "svm-driver")
+        , "jvmti-agent-base", Path.of("substratevm", "mxbuild", "dists", "jdk1.8", "jvmti-agent-base")
+        , "svm-agent", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-agent")
     );
 
     static final Map<String, Path> JDK_PATHS = Map.of(
         "graal-sdk", Path.of("lib", "jvmci", "graal-sdk")
         , "svm", Path.of("lib", "svm", "builder", "svm")
         , "pointsto", Path.of("lib", "svm", "builder", "pointsto")
+        , "library-support", Path.of("lib", "svm", "library-support")
         , "truffle-api", Path.of("lib", "truffle", "truffle-api")
         , "compiler", Path.of("lib", "jvmci", "graal")
         , "objectfile", Path.of("lib", "svm", "builder", "objectfile")
         , "svm-driver", Path.of("lib", "graalvm", "svm-driver")
+        , "jvmti-agent-base", Path.of("lib", "graalvm", "jvmti-agent-base")
+        , "svm-agent", Path.of("lib", "graalvm", "svm-agent")
     );
 
     final Path mvn;
@@ -1573,9 +1591,9 @@ final class Check
         Mx.build(options, exec, replace, identity, identity, javaHome);
         os.assertNumberOfTasks(4);
         os.assertTask("mx clean");
-        os.assertTask("mx --trust-http --java-home java build --no-native --dependencies SVM,SVM_DRIVER");
-        os.assertTask("mx --trust-http --java-home java build --projects com.oracle.svm.native.libchelper,com.oracle.svm.native.jvm.posix");
-        os.assertTask("mx --trust-http --java-home java build --only native-image.image-bash");
+        os.assertTask("mx --trust-http --java-home java --native-images=lib:native-image-agent --exclude-components=nju build --no-native --dependencies SVM,SVM_DRIVER,SVM_AGENT");
+        os.assertTask("mx --trust-http --java-home java --native-images=lib:native-image-agent --exclude-components=nju build --projects com.oracle.svm.native.libchelper,com.oracle.svm.native.jvm.posix");
+        os.assertTask("mx --trust-http --java-home java --native-images=lib:native-image-agent --exclude-components=nju build --only native-image.image-bash,native-image-agent-library_native-image.properties");
     }
 
     private static void shouldEnableAssertions()

--- a/resources/assembly/jvmti-agent-base/pom.xml
+++ b/resources/assembly/jvmti-agent-base/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>36</version>
+    </parent>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>jvmti-agent-base</artifactId>
+    <version>999-ASSEMBLY</version>
+
+    <name>JVMTI Agent Base</name>
+    <description>Base framework for creating a JVMTI agent</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>jvmti-agent-base</artifactId>
+            <version>999-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>999</Implementation-Version>
+                            <Java-Build>${java.vm.version}</Java-Build>
+                        </manifestEntries>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/resources/assembly/library-support/pom.xml
+++ b/resources/assembly/library-support/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>36</version>
+    </parent>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>library-support</artifactId>
+    <version>999-ASSEMBLY</version>
+
+    <name>Library Support</name>
+    <description>SubstrateVM basic library-support components</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>library-support</artifactId>
+            <version>999-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>999</Implementation-Version>
+                            <Java-Build>${java.vm.version}</Java-Build>
+                        </manifestEntries>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/resources/assembly/svm-agent/pom.xml
+++ b/resources/assembly/svm-agent/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>36</version>
+    </parent>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>svm-agent</artifactId>
+    <version>999-ASSEMBLY</version>
+
+    <name>SVM Agent</name>
+    <description>SubstrateVM native-image-agent library</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm-agent</artifactId>
+            <version>999-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>999</Implementation-Version>
+                            <Java-Build>${java.vm.version}</Java-Build>
+                        </manifestEntries>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/resources/release/jvmti-agent-base/pom.xml
+++ b/resources/release/jvmti-agent-base/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>jvmti-agent-base</artifactId>
+    <version>999</version>
+
+    <name>JVMTI Agent Base</name>
+    <description>Base framework for creating a JVMTI agent</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+</project>

--- a/resources/release/library-support/pom.xml
+++ b/resources/release/library-support/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>library-support</artifactId>
+    <version>999</version>
+
+    <name>Library Support</name>
+    <description>SubstrateVM basic library-support components</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+</project>

--- a/resources/release/svm-agent/pom.xml
+++ b/resources/release/svm-agent/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>svn-agent</artifactId>
+    <version>999</version>
+
+    <name>SVM Agent</name>
+    <description>SubstrateVM native-image-agent library</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+</project>


### PR DESCRIPTION
This PR builds and install all the necessary dependencies to build `native-image-agent.so` using:
`native-image --macro:native-image-agent-library`

The changes in this PR **DO NOT** build and install `native-image-agent.so`.

Closes #62 