### PR TITLE
Adds support for building Mandrel on Windows

### DIFF
--- a/code-formatting-rules.xml
+++ b/code-formatting-rules.xml
@@ -1,0 +1,39 @@
+<code_scheme name="Aeron" version="173">
+  <option name="RIGHT_MARGIN" value="80" />
+  <option name="SOFT_MARGINS" value="80" />
+  <JavaCodeStyleSettings>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999999999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999999999" />
+  </JavaCodeStyleSettings>
+  <MarkdownNavigatorCodeStyleSettings>
+    <option name="RIGHT_MARGIN" value="72" />
+  </MarkdownNavigatorCodeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <option name="BRACE_STYLE" value="2" />
+    <option name="CLASS_BRACE_STYLE" value="2" />
+    <option name="METHOD_BRACE_STYLE" value="2" />
+    <option name="LAMBDA_BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="CASE_STATEMENT_ON_NEW_LINE" value="false" />
+    <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+    <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+    <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JavaScript">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="Shell Script">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
- Windows support
- zip archive support for both Linux and Windows
- formatting according to the committed code-formatting-rules.xml
- some type/stylistic changes that made it easier for me to work with it but I can revert...

Building on Windows
------------------

* Installed Visual Studio (C/C++ support)
* Installed Python 2.7 and on PATH  (de facto mx requirements)
* Downloaded OpenJDK
* git et co., e.g. from https://github.com/cmderdev/cmder/releases/download/v1.3.16/cmder.zip
* Have on PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
Then:
```
set PYTHONHTTPSVERIFY=0
vcvarsall.bat x86_amd64
set JAVA_HOME=C:\projects\openjdk-11.0.9_11\
set PATH=%JAVA_HOME%\bin;%PATH%
set MAVEN_REPO=C:/projects/.m2
set MANDREL_REPO=C:/projects/graal/graal
set MX_HOME=C:/projects/graal/mx
set MANDREL_HOME=C:/projects/graal/mandrel-java11-windows-amd64-20.2-SNAPSHOT
%JAVA_HOME%/bin/java -ea build.java --maven-local-repository %MAVEN_REPO% --mandrel-repo %MANDREL_REPO% --mx-home %MX_HOME% --mandrel-version 20.2-SNAPSHOT --mandrel-home %MANDREL_HOME% --archive-suffix zip --verbose
```

# Status

It works, it builds Quarkus app on Windows and Linux (i.e. Linux build is not broken) in a "clean room" env. I will be doing some additional work though:
 * fix asserts in ```     static void checkMx() ``` method
 * cleanup some TODOs, e.g. superfluous flag ```--force-bash-launchers=false```
 * running the Mandrel build in clean room to make absolutely certain that the dependencies and prerequisites are only those listed above

The overall picture is working and O.K. though....