### PR TITLE
Add native-image-launcher macro

### DIFF
--- a/build.java
+++ b/build.java
@@ -140,6 +140,8 @@ public class build
         logger.debugf("Copy macros...");
         fs.copyDirectory(mandrelRepo.resolve(Path.of("sdk", "mxbuild", "native-image.properties", "native-image-agent-library")),
             mandrelHome.resolve(Path.of("lib", "svm", "macros", "native-image-agent-library")));
+        fs.copyDirectory(mandrelRepo.resolve(Path.of("sdk", "mxbuild", "native-image.properties", "native-image-launcher")),
+            mandrelHome.resolve(Path.of("lib", "svm", "macros", "native-image-launcher")));
 
         logger.debugf("Patch native image...");
         patchNativeImageLauncher(nativeImage, options.mandrelVersion);
@@ -647,10 +649,12 @@ class Mx
         , BuildArgs.of("--only",
             build.IS_WINDOWS ?
                 "native-image.exe.image-bash," +
-                    "native-image-agent-library_native-image.properties"
+                    "native-image-agent-library_native-image.properties," +
+                    "native-image-launcher_native-image.properties"
                 :
                 "native-image.image-bash," +
-                    "native-image-agent-library_native-image.properties")
+                    "native-image-agent-library_native-image.properties," +
+                    "native-image-launcher_native-image.properties")
     );
 
     static void build(


### PR DESCRIPTION
This PR adds the `native-image-launcher` macro to the Mandrel distributions.
This enables users to build the binary native-image by running:
`native-image --macro:native-image-launcher`
This way they may use features that are only available in the binary `native-image`, e.g. using a build server.

This PR depends on https://github.com/oracle/graal/pull/2961 for returning the proper Java version when running `native-image --version` with the binary `native-image`. Right now it returns something like:
```
GraalVM Version 20.1.0.4-dev (Mandrel Distribution) (Java Version null)
```

