### PR TITLE
All upstream Jenkins jobs related to Mandrel are encoded in Jenkins DSL now

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,10 @@
+# Mandrel Jenkins jobs
+
+Mandrel jobs use [Jenkins Job DSL](https://github.com/jenkinsci/job-dsl-plugin), a Groovy-based DSL.
+
+Useful links:
+
+- [Job DSL API viewer on Jenkins](https://ci.modcluster.io/plugin/job-dsl/api-viewer/index.html)
+
+## Update job
+- If you run [mandrel-jobs](https://ci.modcluster.io/job/mandrel-jobs/) you regenerate Jenkins jobs definitions. 

--- a/jenkins/jobs/graal_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/graal_windows_quarkus_tests.groovy
@@ -1,0 +1,82 @@
+matrixJob('graal-windows-quarkus-tests') {
+    axes {
+        text('GRAAL_VERSION',
+                '20.3.0',
+                '20.2.0'
+        )
+        text('QUARKUS_VERSION',
+                '1.10.5.Final',
+                'master'
+        )
+        labelExpression('LABEL', ['w2k19'])
+    }
+    description('Run Quarkus TS with GraalVM distros.')
+    displayName('Windows (Graal) :: Quarkus TS')
+    logRotator {
+        numToKeep(3)
+    }
+    childCustomWorkspace('${SHORT_COMBINATION}')
+    wrappers {
+        timestamps()
+        timeout {
+            absolute(360)
+        }
+    }
+    combinationFilter('(GRAAL_VERSION=="20.3.0" && QUARKUS_VERSION=="master") ||' +
+            ' (GRAAL_VERSION=="20.2.0" && QUARKUS_VERSION=="1.10.5.Final")')
+    parameters {
+        stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')
+    }
+    steps {
+        batchFile('''
+REM Prepare Mandrel
+@echo off
+call vcvars64
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+set "GRAALVM_HOME=C:\\Program Files\\graalvm-ce-java11-%GRAAL_VERSION%"
+set "JAVA_HOME=%GRAALVM_HOME%"
+set "PATH=%JAVA_HOME%\\bin;%PATH%"
+
+if not exist "%GRAALVM_HOME%\\bin\\native-image.cmd" (
+  echo "Cannot find native-image tool. Quitting..."
+  exit 1
+) else (
+  echo "native-image.cmd is present, good."
+  cmd /C native-image --version
+)
+
+REM Prepare Quarkus
+git clone --depth 1 --branch %QUARKUS_VERSION% %QUARKUS_REPO%
+cd quarkus
+
+REM Build and test Quarkus
+
+set "MODULES=-pl !google-cloud-functions,!google-cloud-functions-http,!kubernetes/maven-invoker-way,!kubernetes-client"
+
+mvnw clean install -DskipTests -pl '!docs' & mvnw verify -f integration-tests/pom.xml --fail-at-end --batch-mode -DfailIfNoTests=false -Dnative %MODULES%
+
+        ''')
+    }
+    publishers {
+        archiveJunit('**/target/*-reports/*.xml') {
+            allowEmptyResults(false)
+            retainLongStdout(false)
+            healthScaleFactor(1.0)
+        }
+        archiveArtifacts('**/target/*-reports/*.xml')
+
+        extendedEmail {
+            recipientList('karm@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        wsCleanup()
+    }
+}

--- a/jenkins/jobs/graal_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/graal_windows_quarkus_tests.groovy
@@ -5,7 +5,7 @@ matrixJob('graal-windows-quarkus-tests') {
                 '20.2.0'
         )
         text('QUARKUS_VERSION',
-                '1.10.5.Final',
+                '1.11.0.Beta1',
                 'master'
         )
         labelExpression('LABEL', ['w2k19'])
@@ -23,7 +23,7 @@ matrixJob('graal-windows-quarkus-tests') {
         }
     }
     combinationFilter('(GRAAL_VERSION=="20.3.0" && QUARKUS_VERSION=="master") ||' +
-            ' (GRAAL_VERSION=="20.2.0" && QUARKUS_VERSION=="1.10.5.Final")')
+            ' (GRAAL_VERSION=="20.2.0" && QUARKUS_VERSION=="1.11.0.Beta1")')
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')
     }

--- a/jenkins/jobs/mandrel_20_1_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_1_linux_build.groovy
@@ -45,8 +45,8 @@ Linux build for 20.1 branch.
         choiceParam(
                 'PACKAGING_REPOSITORY',
                 [
-                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/zakkak/mandrel-packaging.git'
                 ],
                 'Mandrel packaging scripts.'
@@ -62,7 +62,7 @@ Linux build for 20.1 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                '20.1-jenkins',
+                '20.1',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(

--- a/jenkins/jobs/mandrel_20_1_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_1_linux_build.groovy
@@ -1,0 +1,139 @@
+job('mandrel-20.1-linux-build') {
+    label 'centos8'
+    displayName('Linux Build :: 20.1')
+    description('''
+Linux build for 20.1 branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'mandrel/20.1',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                '20.1-jenkins',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                '20.1-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        shell('echo MANDREL_VERSION_SUBSTRING=${MANDREL_VERSION_SUBSTRING}')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        shell('./jenkins/jobs/scripts/mandrel_linux_build.sh')
+    }
+    publishers {
+        archiveArtifacts('*.tar.gz,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=20.1,QUARKUS_VERSION=1.7.5.Final/',
+                     'mandrel-linux-integration-tests/MANDREL_VERSION=20.1,label=el8']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_20_2_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_2_linux_build.groovy
@@ -1,0 +1,138 @@
+job('mandrel-20.2-linux-build') {
+    label 'centos8'
+    displayName('Linux Build :: 20.2')
+    description('''
+Linux build for 20.2 branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'mandrel/20.2',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                '20.1-jenkins',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                '20.2-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        shell('echo MANDREL_VERSION_SUBSTRING=${MANDREL_VERSION_SUBSTRING}')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        shell('./jenkins/jobs/scripts/mandrel_linux_build.sh')
+    }
+    publishers {
+        archiveArtifacts('*.tar.gz,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-linux-integration-tests/MANDREL_VERSION=20.2,label=el8']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_20_2_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_2_linux_build.groovy
@@ -45,8 +45,8 @@ Linux build for 20.2 branch.
         choiceParam(
                 'PACKAGING_REPOSITORY',
                 [
-                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/zakkak/mandrel-packaging.git'
                 ],
                 'Mandrel packaging scripts.'
@@ -62,7 +62,7 @@ Linux build for 20.2 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                '20.1-jenkins',
+                '20.1',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(

--- a/jenkins/jobs/mandrel_20_2_windows_build.groovy
+++ b/jenkins/jobs/mandrel_20_2_windows_build.groovy
@@ -1,0 +1,139 @@
+job('mandrel-20.2-windows-build') {
+    label 'w2k19'
+    displayName('Windows Build :: 20.2')
+    description('''
+Windows build for 20.2 branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'mandrel/20.2',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                '20.1-jenkins',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                '20.2-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        batchFile('echo MANDREL_VERSION_SUBSTRING=%MANDREL_VERSION_SUBSTRING%')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        batchFile('cmd /C jenkins\\jobs\\scripts\\mandrel_windows_build.bat')
+    }
+    publishers {
+        archiveArtifacts('*.zip,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-windows-integration-tests/MANDREL_VERSION=20.2,label=w2k19/']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_20_2_windows_build.groovy
+++ b/jenkins/jobs/mandrel_20_2_windows_build.groovy
@@ -45,8 +45,8 @@ Windows build for 20.2 branch.
         choiceParam(
                 'PACKAGING_REPOSITORY',
                 [
-                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/zakkak/mandrel-packaging.git'
 
                 ],
@@ -63,7 +63,7 @@ Windows build for 20.2 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                '20.1-jenkins',
+                '20.1',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(

--- a/jenkins/jobs/mandrel_20_3_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_linux_build.groovy
@@ -45,8 +45,8 @@ Linux build for 20.3 branch.
         choiceParam(
                 'PACKAGING_REPOSITORY',
                 [
-                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/zakkak/mandrel-packaging.git'
                 ],
                 'Mandrel packaging scripts.'
@@ -62,7 +62,7 @@ Linux build for 20.3 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                'jenkins',
+                'master',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(
@@ -127,7 +127,7 @@ Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarba
             }
         }
         downstreamParameterized {
-            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=20.3,QUARKUS_VERSION=1.10.5.Final/',
+            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=20.3,QUARKUS_VERSION=1.11.0.Beta1/',
                      'mandrel-linux-integration-tests/MANDREL_VERSION=20.3,label=el8']) {
                 condition('SUCCESS')
                 parameters {

--- a/jenkins/jobs/mandrel_20_3_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_linux_build.groovy
@@ -1,0 +1,139 @@
+job('mandrel-20.3-linux-build') {
+    label 'centos8'
+    displayName('Linux Build :: 20.3')
+    description('''
+Linux build for 20.3 branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'mandrel/20.3',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                'jenkins',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                '20.3-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        shell('echo MANDREL_VERSION_SUBSTRING=${MANDREL_VERSION_SUBSTRING}')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        shell('./jenkins/jobs/scripts/mandrel_linux_build.sh')
+    }
+    publishers {
+        archiveArtifacts('*.tar.gz,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=20.3,QUARKUS_VERSION=1.10.5.Final/',
+                     'mandrel-linux-integration-tests/MANDREL_VERSION=20.3,label=el8']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_20_3_windows_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_windows_build.groovy
@@ -45,8 +45,8 @@ Windows build for 20.3 branch.
         choiceParam(
                 'PACKAGING_REPOSITORY',
                 [
-                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/zakkak/mandrel-packaging.git'
                 ],
                 'Mandrel packaging scripts.'
@@ -62,7 +62,7 @@ Windows build for 20.3 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                '20.1-jenkins',
+                '20.1',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(
@@ -127,7 +127,7 @@ Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarba
             }
         }
         downstreamParameterized {
-            trigger(['mandrel-windows-quarkus-tests/LABEL=w2k19,MANDREL_VERSION=20.3,QUARKUS_VERSION=1.10.5.Final/',
+            trigger(['mandrel-windows-quarkus-tests/LABEL=w2k19,MANDREL_VERSION=20.3,QUARKUS_VERSION=1.11.0.Beta1/',
                      'mandrel-windows-integration-tests/MANDREL_VERSION=20.3,label=w2k19/']) {
                 condition('SUCCESS')
                 parameters {

--- a/jenkins/jobs/mandrel_20_3_windows_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_windows_build.groovy
@@ -1,0 +1,139 @@
+job('mandrel-20.3-windows-build') {
+    label 'w2k19'
+    displayName('Windows Build :: 20.3')
+    description('''
+Windows build for 20.3 branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'mandrel/20.3',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                '20.1-jenkins',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                '20.3-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        batchFile('echo MANDREL_VERSION_SUBSTRING=%MANDREL_VERSION_SUBSTRING%')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        batchFile('cmd /C jenkins\\jobs\\scripts\\mandrel_windows_build.bat')
+    }
+    publishers {
+        archiveArtifacts('*.zip,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-windows-quarkus-tests/LABEL=w2k19,MANDREL_VERSION=20.3,QUARKUS_VERSION=1.10.5.Final/',
+                     'mandrel-windows-integration-tests/MANDREL_VERSION=20.3,label=w2k19/']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_jobs.groovy
+++ b/jenkins/jobs/mandrel_jobs.groovy
@@ -1,0 +1,20 @@
+job('mandrel-jobs') {
+    description('Update all Mandrel Jenkins jobs from https://github.com/graalvm/mandrel-packaging/tree/master/jenkins')
+    label('el8||master')
+    logRotator {
+        numToKeep(1)
+    }
+    scm {
+        git {
+            remote {
+                url('https://github.com/graalvm/mandrel-packaging.git')
+            }
+            branch('master')
+        }
+    }
+    steps {
+        dsl {
+            external('jenkins/jobs/**/*.groovy')
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_linux_container_integration_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_container_integration_tests.groovy
@@ -1,0 +1,74 @@
+matrixJob('mandrel-linux-container-integration-tests') {
+    axes {
+        text('BUILDER_IMAGE',
+                'quay.io/quarkus/ubi-quarkus-mandrel:20.1-java11',
+                'quay.io/quarkus/ubi-quarkus-mandrel:20.2-java11',
+                'quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11',
+                'registry.access.redhat.com/quarkus/mandrel-20-rhel8',
+                'registry-proxy.engineering.redhat.com/rh-osbs/quarkus-quarkus-mandrel-20-rhel8'
+        )
+        labelExpression('label', ['el8'])
+    }
+    description('Run Mandrel container integration tests')
+    displayName('Linux :: Container Integration tests')
+    logRotator {
+        numToKeep(3)
+    }
+    childCustomWorkspace('${SHORT_COMBINATION}')
+    wrappers {
+        timestamps()
+        timeout {
+            absolute(120)
+        }
+    }
+    //combinationFilter('jdk=="jdk-8" || label=="linux"')
+    parameters {
+        stringParam('MANDREL_INTEGRATION_TESTS_REPO', 'https://github.com/Karm/mandrel-integration-tests.git', 'Test suite repository.')
+        choiceParam(
+                'MANDREL_INTEGRATION_TESTS_REF_TYPE',
+                ['heads', 'tags'],
+                'Choose "heads" if you want to build from a branch, or "tags" if you want to build from a tag.'
+        )
+        stringParam('MANDREL_INTEGRATION_TESTS_REF', 'master', 'Branch or tag.')
+    }
+    scm {
+        git {
+            remote {
+                url('${MANDREL_INTEGRATION_TESTS_REPO}')
+            }
+            branch('refs/${MANDREL_INTEGRATION_TESTS_REF_TYPE}/${MANDREL_INTEGRATION_TESTS_REF}')
+        }
+    }
+
+    steps {
+        shell('echo DESCRIPTION_STRING=${BUILDER_IMAGE}')
+        buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
+        shell('''
+            docker volume prune
+            export JAVA_HOME="/usr/java/openjdk-11-latest"
+            export PATH="${JAVA_HOME}/bin:${PATH}"
+            mvn clean verify -Ptestsuite-builder-image -Dquarkus.native.builder-image=${BUILDER_IMAGE}
+        ''')
+    }
+    publishers {
+        archiveJunit('**/target/*-reports/*.xml') {
+            allowEmptyResults(false)
+            retainLongStdout(false)
+            healthScaleFactor(1.0)
+        }
+        archiveArtifacts('**/target/*-reports/*.xml,**/target/archived-logs/**')
+
+        extendedEmail {
+            recipientList('karm@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        wsCleanup()
+    }
+}

--- a/jenkins/jobs/mandrel_linux_integration_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_integration_tests.groovy
@@ -1,0 +1,91 @@
+matrixJob('mandrel-linux-integration-tests') {
+    axes {
+        text('MANDREL_VERSION',
+                '20.1',
+                '20.2',
+                '20.3',
+                'master'
+        )
+        labelExpression('label', ['el8'])
+    }
+    description('Run Mandrel integration tests')
+    displayName('Linux :: Integration tests')
+    logRotator {
+        numToKeep(3)
+    }
+    childCustomWorkspace('${SHORT_COMBINATION}')
+    wrappers {
+        timestamps()
+        timeout {
+            absolute(120)
+        }
+    }
+    //combinationFilter('jdk=="jdk-8" || label=="linux"')
+    parameters {
+        stringParam('MANDREL_INTEGRATION_TESTS_REPO', 'https://github.com/Karm/mandrel-integration-tests.git', 'Test suite repository.')
+        choiceParam(
+                'MANDREL_INTEGRATION_TESTS_REF_TYPE',
+                ['heads', 'tags'],
+                'Choose "heads" if you want to build from a branch, or "tags" if you want to build from a tag.'
+        )
+        stringParam('MANDREL_INTEGRATION_TESTS_REF', 'master', 'Branch or tag.')
+    }
+    scm {
+        git {
+            remote {
+                url('${MANDREL_INTEGRATION_TESTS_REPO}')
+            }
+            branch('refs/${MANDREL_INTEGRATION_TESTS_REF_TYPE}/${MANDREL_INTEGRATION_TESTS_REF}')
+        }
+    }
+
+    steps {
+        shell('''
+            case $MANDREL_VERSION in
+                20.1)    BUILD_JOB='mandrel-20.1-linux-build';;
+                20.2)    BUILD_JOB='mandrel-20.2-linux-build';;
+                20.3)    BUILD_JOB='mandrel-20.3-linux-build';;
+                master)  BUILD_JOB='mandrel-master-linux-build';;
+                *)
+                    echo "UNKNOWN Mandrel version: $MANDREL_VERSION"
+                    exit 1
+            esac
+            
+            wget "https://ci.modcluster.io/view/Mandrel/job/${BUILD_JOB}/lastSuccessfulBuild/artifact/*zip*/archive.zip" --no-check-certificate 
+            unzip archive.zip
+            pushd archive
+            MANDREL_TAR=`ls -1 *.tar.gz`
+            tar -xvf "${MANDREL_TAR}"
+            export JAVA_HOME="$( pwd )/$( echo mandrel-java11*-*/ )"
+            export GRAALVM_HOME="${JAVA_HOME}"
+            export PATH="${JAVA_HOME}/bin:${PATH}"
+            if [[ ! -e "${JAVA_HOME}/bin/native-image" ]]; then
+                echo "Cannot find native-image tool. Quitting..."
+                exit 1
+            fi
+            popd
+            mvn clean verify -Ptestsuite
+        ''')
+    }
+    publishers {
+        archiveJunit('**/target/*-reports/*.xml') {
+            allowEmptyResults(false)
+            retainLongStdout(false)
+            healthScaleFactor(1.0)
+        }
+        archiveArtifacts('**/target/*-reports/*.xml,**/target/archived-logs/**')
+
+        extendedEmail {
+            recipientList('karm@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        wsCleanup()
+    }
+}

--- a/jenkins/jobs/mandrel_linux_quarkus_container_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_quarkus_container_tests.groovy
@@ -1,0 +1,88 @@
+job('mandrel-linux-quarkus-container-tests') {
+    label('el8')
+    description('Run Quarkus TS with Mandrel distros. Quarkus versions differ according to particular Mandrel versions.')
+    displayName('Linux :: Quarkus Builder image TS')
+    logRotator {
+        numToKeep(3)
+    }
+    wrappers {
+        timestamps()
+        timeout {
+            absolute(600)
+        }
+    }
+    parameters {
+        stringParam('CONTAINER_IMAGE', 'quay.io/quarkus/ubi-quarkus-mandrel:20.1-java11', 'Mandrel builder image.')
+        stringParam('CONTAINER_RUNTIME', 'docker', 'Command used, either "docker" or "podman". Note that podman is not installed on all executors...')
+        stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')
+        stringParam('QUARKUS_VERSION', '1.7.5.Final', 'Quarkus version branch or tag.')
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK installation.'
+        )
+    }
+    steps {
+        shell('echo DESCRIPTION_STRING=Quarkus${QUARKUS_VERSION},${CONTAINER_IMAGE}')
+        buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
+        shell('''
+            # Prepare Quarkus
+            git clone --depth 1 --branch ${QUARKUS_VERSION} ${QUARKUS_REPO}
+            cd quarkus
+
+            # Env
+            export JAVA_HOME=/usr/java/${OPENJDK}
+            export PATH=${JAVA_HOME}/bin:${PATH}
+            set +e
+            docker stop $(docker ps -a -q)
+            docker rm $(docker ps -a -q)
+            docker volume prune
+            set -e
+            docker pull ${CONTAINER_IMAGE}
+            if [ "$?" -ne 0 ]; then
+                echo There was a problem pulling the image ${CONTAINER_IMAGE}. We cannot proceed.
+                exit 1
+            fi
+            
+            # Build Quarkus
+            ./mvnw clean install -DskipTests -pl '!docs'
+            
+            # Test Quarkus
+            export MODULES="-pl \\
+!google-cloud-functions,\\
+!maven"
+            
+            ./mvnw verify -f integration-tests/pom.xml --fail-at-end \\
+   ${MODULES} -Dno-format -Ddocker -Dnative \\
+  -Dquarkus.native.container-build=true \\
+  -Dquarkus.native.builder-image="${CONTAINER_IMAGE}" \\
+  -Dquarkus.native.container-runtime=${CONTAINER_RUNTIME}
+        ''')
+    }
+    publishers {
+        archiveJunit('**/target/*-reports/*.xml') {
+            allowEmptyResults(false)
+            retainLongStdout(false)
+            healthScaleFactor(1.0)
+        }
+        archiveArtifacts('**/target/*-reports/*.xml')
+
+        extendedEmail {
+            recipientList('karm@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        wsCleanup()
+    }
+}

--- a/jenkins/jobs/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_quarkus_tests.groovy
@@ -1,0 +1,112 @@
+matrixJob('mandrel-linux-quarkus-tests') {
+    axes {
+        text('MANDREL_VERSION',
+                '20.1',
+                '20.3',
+                'master'
+        )
+        text('QUARKUS_VERSION',
+                '1.10.5.Final',
+                '1.7.5.Final'
+        )
+        labelExpression('LABEL', ['el8', 'el7||just_smoke_test'])
+    }
+    description('Run Quarkus TS with Mandrel distros. Quarkus versions differ according to particular Mandrel versions.')
+    displayName('Linux :: Quarkus TS')
+    logRotator {
+        numToKeep(3)
+    }
+    childCustomWorkspace('${SHORT_COMBINATION}')
+    wrappers {
+        timestamps()
+        timeout {
+            absolute(360)
+        }
+    }
+    combinationFilter('(MANDREL_VERSION=="20.1" && QUARKUS_VERSION=="1.7.5.Final") ||' +
+            ' ((MANDREL_VERSION=="20.3" || MANDREL_VERSION=="master") && QUARKUS_VERSION=="1.10.5.Final")')
+    parameters {
+        stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')
+    }
+    steps {
+        shell('''
+            # Prepare Mandrel
+            case $MANDREL_VERSION in
+                20.1)    BUILD_JOB='mandrel-20.1-linux-build';;
+                20.3)    BUILD_JOB='mandrel-20.3-linux-build';;
+                master)  BUILD_JOB='mandrel-master-linux-build';;
+                *)
+                    echo "UNKNOWN Mandrel version: $MANDREL_VERSION"
+                    exit 1
+            esac
+            wget "https://ci.modcluster.io/view/Mandrel/job/${BUILD_JOB}/lastSuccessfulBuild/artifact/*zip*/archive.zip" --no-check-certificate 
+            unzip archive.zip
+            pushd archive
+            MANDREL_TAR=`ls -1 *.tar.gz`
+            tar -xvf "${MANDREL_TAR}"
+            export JAVA_HOME="$( pwd )/$( echo mandrel-java11*-*/ )"
+            export GRAALVM_HOME="${JAVA_HOME}"
+            export PATH="${JAVA_HOME}/bin:${PATH}"
+            popd
+            if [[ ! -e "${JAVA_HOME}/bin/native-image" ]]; then
+                echo "Cannot find native-image tool. Quitting..."
+                exit 1
+            fi
+            
+            # Prepare Quarkus
+            git clone --depth 1 --branch ${QUARKUS_VERSION} ${QUARKUS_REPO}
+            cd quarkus
+            
+            # Build Quarkus
+            ./mvnw clean install -DskipTests -pl '!docs'
+            
+            # Test Quarkus
+             if [[ "${LABEL}" =~ "el8" ]]; then
+                export MODULES="-pl \\
+!google-cloud-functions,\\
+!google-cloud-functions-http,\\
+!kubernetes/maven-invoker-way"
+             else
+                # The rest runs a subset, el7 VM has just 8G RAM
+                export MODULES="-pl \\
+bootstrap-config,\\
+class-transformer,\\
+common-jpa-entities,\\
+elytron-resteasy,\\
+jackson,\\
+logging-gelf,\\
+packaging,\\
+quartz,\\
+rest-client,\\
+resteasy-jackson,\\
+resteasy-mutiny,\\
+shared-library,\\
+test-extension,\\
+vertx-graphql,\\
+virtual-http-resteasy"
+             fi
+            ./mvnw verify -f integration-tests/pom.xml --fail-at-end --batch-mode -DfailIfNoTests=false -Dnative ${MODULES}
+        ''')
+    }
+    publishers {
+        archiveJunit('**/target/*-reports/*.xml') {
+            allowEmptyResults(false)
+            retainLongStdout(false)
+            healthScaleFactor(1.0)
+        }
+        archiveArtifacts('**/target/*-reports/*.xml')
+
+        extendedEmail {
+            recipientList('karm@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        wsCleanup()
+    }
+}

--- a/jenkins/jobs/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_quarkus_tests.groovy
@@ -6,7 +6,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
                 'master'
         )
         text('QUARKUS_VERSION',
-                '1.10.5.Final',
+                '1.11.0.Beta1',
                 '1.7.5.Final'
         )
         labelExpression('LABEL', ['el8', 'el7||just_smoke_test'])
@@ -24,7 +24,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
         }
     }
     combinationFilter('(MANDREL_VERSION=="20.1" && QUARKUS_VERSION=="1.7.5.Final") ||' +
-            ' ((MANDREL_VERSION=="20.3" || MANDREL_VERSION=="master") && QUARKUS_VERSION=="1.10.5.Final")')
+            ' ((MANDREL_VERSION=="20.3" || MANDREL_VERSION=="master") && QUARKUS_VERSION=="1.11.0.Beta1")')
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')
     }

--- a/jenkins/jobs/mandrel_master_linux_build.groovy
+++ b/jenkins/jobs/mandrel_master_linux_build.groovy
@@ -44,8 +44,8 @@ Linux build for master branch.
         choiceParam(
                 'PACKAGING_REPOSITORY',
                 [
-                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/zakkak/mandrel-packaging.git'
 
                 ],
@@ -62,7 +62,7 @@ Linux build for master branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                'jenkins',
+                'master',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(
@@ -127,7 +127,7 @@ Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarba
             }
         }
         downstreamParameterized {
-            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=master,QUARKUS_VERSION=1.10.5.Final/',
+            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=master,QUARKUS_VERSION=1.11.0.Beta1/',
                      'mandrel-linux-integration-tests/MANDREL_VERSION=master,label=el8']) {
                 condition('SUCCESS')
                 parameters {

--- a/jenkins/jobs/mandrel_master_linux_build.groovy
+++ b/jenkins/jobs/mandrel_master_linux_build.groovy
@@ -1,0 +1,139 @@
+job('mandrel-master-linux-build') {
+    label 'centos8'
+    displayName('Linux Build :: master')
+    description('''
+Linux build for master branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'graal/master',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                'jenkins',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                'master-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        shell('echo MANDREL_VERSION_SUBSTRING=${MANDREL_VERSION_SUBSTRING}')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        shell('./jenkins/jobs/scripts/mandrel_linux_build.sh')
+    }
+    publishers {
+        archiveArtifacts('*.tar.gz,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=master,QUARKUS_VERSION=1.10.5.Final/',
+                     'mandrel-linux-integration-tests/MANDREL_VERSION=master,label=el8']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_master_linux_build_labsjdk.groovy
+++ b/jenkins/jobs/mandrel_master_linux_build_labsjdk.groovy
@@ -161,7 +161,7 @@ if [[ "`./hello`" == "Hello." ]]; then echo Done; else echo Native image fail;ex
             }
         }
         downstreamParameterized {
-            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=master,QUARKUS_VERSION=1.10.5.Final/',
+            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=master,QUARKUS_VERSION=1.11.0.Beta1/',
                      'mandrel-linux-integration-tests/MANDREL_VERSION=master,label=el8']) {
                 condition('SUCCESS')
                 parameters {

--- a/jenkins/jobs/mandrel_master_linux_build_labsjdk.groovy
+++ b/jenkins/jobs/mandrel_master_linux_build_labsjdk.groovy
@@ -1,0 +1,173 @@
+job('mandrel-master-linux-build-labsjdk') {
+    label 'centos8'
+    displayName('Linux Build :: master labsjdk')
+    description('''
+Linux build for master branch with LabsJDK
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'graal/master',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'labsjdk-ce-11-latest',
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git'
+
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                'master',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                'master-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        shell('echo MANDREL_VERSION_SUBSTRING=${MANDREL_VERSION_SUBSTRING}')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        shell('''
+export JAVA_HOME=/usr/java/${OPENJDK}
+export MX_HOME=${WORKSPACE}/mx
+export PATH=${JAVA_HOME}/bin:${MX_HOME}:${PATH}
+pushd mandrel
+pushd substratevm
+mx --java-home=${JAVA_HOME} build
+popd
+BUILD=./sdk/mxbuild/linux-amd64/GRAALVM_*_JAVA11/graalvm-*-java11-*-dev
+MANDREL_DIR=mandrel-labsjava11-${MANDREL_VERSION_SUBSTRING}-SNAPSHOT
+mv ${BUILD} ${MANDREL_DIR}
+export MANDREL_HOME="$(pwd)/${MANDREL_DIR}"
+TAR_NAME=mandrel-labsjava11-linux-amd64-${MANDREL_VERSION_SUBSTRING}-SNAPSHOT.tar.gz
+tar -czf ${TAR_NAME} ${MANDREL_DIR}
+sha1sum ${TAR_NAME}>${TAR_NAME}.sha1
+echo "This is not a proper Mandrel build, this is an experiment with LabsJDK" >> README.md
+if [[ ! -e "${MANDREL_HOME}/bin/native-image" ]]; then
+  echo "Cannot find native-image tool. Quitting..."
+  exit 1
+fi
+cat >./Hello.java <<EOL
+public class Hello {
+public static void main(String[] args) {
+    System.out.println("Hello.");
+}
+}
+EOL
+export JAVA_HOME=${MANDREL_HOME}
+export PATH=${JAVA_HOME}/bin:${PATH}
+javac Hello.java
+native-image Hello
+if [[ "`./hello`" == "Hello." ]]; then echo Done; else echo Native image fail;exit 1;fi
+                 ''')
+    }
+    publishers {
+        archiveArtifacts('*.tar.gz,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=master,QUARKUS_VERSION=1.10.5.Final/',
+                     'mandrel-linux-integration-tests/MANDREL_VERSION=master,label=el8']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_master_windows_build.groovy
+++ b/jenkins/jobs/mandrel_master_windows_build.groovy
@@ -45,8 +45,8 @@ Windows build for master branch.
         choiceParam(
                 'PACKAGING_REPOSITORY',
                 [
-                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
                         'https://github.com/zakkak/mandrel-packaging.git'
                 ],
                 'Mandrel packaging scripts.'
@@ -62,7 +62,7 @@ Windows build for master branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                '20.1-jenkins',
+                '20.1',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(

--- a/jenkins/jobs/mandrel_master_windows_build.groovy
+++ b/jenkins/jobs/mandrel_master_windows_build.groovy
@@ -1,0 +1,139 @@
+job('mandrel-master-windows-build') {
+    label 'w2k19'
+    displayName('Windows Build :: master')
+    description('''
+Windows build for master branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'graal/master',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                '20.1-jenkins',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                'master-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        batchFile('echo MANDREL_VERSION_SUBSTRING=%MANDREL_VERSION_SUBSTRING%')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        batchFile('cmd /C jenkins\\jobs\\scripts\\mandrel_windows_build.bat')
+    }
+    publishers {
+        archiveArtifacts('*.zip,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-windows-quarkus-tests/LABEL=w2k19,MANDREL_VERSION=master,QUARKUS_VERSION=master/',
+                     'mandrel-windows-integration-tests/MANDREL_VERSION=master,label=w2k19/']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_windows_integration_tests.groovy
+++ b/jenkins/jobs/mandrel_windows_integration_tests.groovy
@@ -1,0 +1,114 @@
+matrixJob('mandrel-windows-integration-tests') {
+    axes {
+        text('MANDREL_VERSION',
+                '20.2',
+                '20.3',
+                'master'
+        )
+        labelExpression('label', ['w2k19'])
+    }
+    description('Run Mandrel integration tests')
+    displayName('Windows :: Integration tests')
+    logRotator {
+        numToKeep(3)
+    }
+    childCustomWorkspace('${SHORT_COMBINATION}')
+    wrappers {
+        timestamps()
+        timeout {
+            absolute(120)
+        }
+    }
+    //combinationFilter('jdk=="jdk-8" || label=="linux"')
+    parameters {
+        stringParam('MANDREL_INTEGRATION_TESTS_REPO', 'https://github.com/Karm/mandrel-integration-tests.git', 'Test suite repository.')
+        choiceParam(
+                'MANDREL_INTEGRATION_TESTS_REF_TYPE',
+                ['heads', 'tags'],
+                'Choose "heads" if you want to build from a branch, or "tags" if you want to build from a tag.'
+        )
+        stringParam('MANDREL_INTEGRATION_TESTS_REF', 'master', 'Branch or tag.')
+    }
+    scm {
+        git {
+            remote {
+                url('${MANDREL_INTEGRATION_TESTS_REPO}')
+            }
+            branch('refs/${MANDREL_INTEGRATION_TESTS_REF_TYPE}/${MANDREL_INTEGRATION_TESTS_REF}')
+        }
+    }
+
+    steps {
+        batchFile('''
+@echo off
+call vcvars64
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+set BUILD_JOB=""
+IF "%MANDREL_VERSION%"=="20.2" (
+    set BUILD_JOB=mandrel-20.2-windows-build
+) ELSE IF "%MANDREL_VERSION%"=="20.3" (
+    set BUILD_JOB=mandrel-20.3-windows-build
+) ELSE IF "%MANDREL_VERSION%"=="master" (
+    set BUILD_JOB=mandrel-master-windows-build
+) ELSE (
+    echo "UNKNOWN Mandrel version: %MANDREL_VERSION%"
+    exit 1
+)
+
+set downloadCommand= ^
+$c = New-Object System.Net.WebClient; ^
+$url = 'https://ci.modcluster.io/view/Mandrel/job/%BUILD_JOB%/lastSuccessfulBuild/artifact/*zip*/archive.zip'; $file = 'archive.zip'; ^
+$c.DownloadFile($url, $file);
+powershell -Command "%downloadCommand%"
+
+powershell -c "Expand-Archive -Path archive.zip -DestinationPath . -Force"
+
+pushd archive
+
+for /f "tokens=5" %%g in ('dir mandrel-*.zip ^| findstr /R mandrel-.*.zip') do set ZIP_NAME=%%g
+
+powershell -c "Expand-Archive -Path %ZIP_NAME% -DestinationPath . -Force"
+echo ZIP_NAME: %ZIP_NAME%
+
+for /f "tokens=5" %%g in ('dir /AD mandrel-* ^| findstr /R mandrel-.*') do set GRAALVM_HOME=%cd%\\%%g
+echo GRAALVM_HOME: %GRAALVM_HOME%
+
+set "JAVA_HOME=%GRAALVM_HOME%"
+set "PATH=%JAVA_HOME%\\bin;%PATH%"
+
+if not exist "%GRAALVM_HOME%\\bin\\native-image.cmd" (
+  echo "Cannot find native-image tool. Quitting..."
+  exit 1
+) else (
+  echo "native-image.cmd is present, good."
+  cmd /C native-image --version
+)
+
+popd
+
+mvn clean verify -Ptestsuite
+                 ''')
+    }
+    publishers {
+        archiveJunit('**/target/*-reports/*.xml') {
+            allowEmptyResults(false)
+            retainLongStdout(false)
+            healthScaleFactor(1.0)
+        }
+        archiveArtifacts('**/target/*-reports/*.xml,**/target/archived-logs/**')
+
+        extendedEmail {
+            recipientList('karm@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        wsCleanup()
+    }
+}

--- a/jenkins/jobs/mandrel_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/mandrel_windows_quarkus_tests.groovy
@@ -5,7 +5,7 @@ matrixJob('mandrel-windows-quarkus-tests') {
                 'master'
         )
         text('QUARKUS_VERSION',
-                '1.10.5.Final',
+                '1.11.0.Beta1',
                 'master'
         )
         labelExpression('LABEL', ['w2k19'])
@@ -22,7 +22,7 @@ matrixJob('mandrel-windows-quarkus-tests') {
             absolute(360)
         }
     }
-    combinationFilter('(MANDREL_VERSION=="20.3" && QUARKUS_VERSION=="1.10.5.Final") ||' +
+    combinationFilter('(MANDREL_VERSION=="20.3" && QUARKUS_VERSION=="1.11.0.Beta1") ||' +
             ' (MANDREL_VERSION=="master" && QUARKUS_VERSION=="master")')
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')

--- a/jenkins/jobs/mandrel_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/mandrel_windows_quarkus_tests.groovy
@@ -1,0 +1,113 @@
+matrixJob('mandrel-windows-quarkus-tests') {
+    axes {
+        text('MANDREL_VERSION',
+                '20.3',
+                'master'
+        )
+        text('QUARKUS_VERSION',
+                '1.10.5.Final',
+                'master'
+        )
+        labelExpression('LABEL', ['w2k19'])
+    }
+    description('Run Quarkus TS with Mandrel distros. Quarkus versions differ according to particular Mandrel versions.')
+    displayName('Windows :: Quarkus TS')
+    logRotator {
+        numToKeep(3)
+    }
+    childCustomWorkspace('${SHORT_COMBINATION}')
+    wrappers {
+        timestamps()
+        timeout {
+            absolute(360)
+        }
+    }
+    combinationFilter('(MANDREL_VERSION=="20.3" && QUARKUS_VERSION=="1.10.5.Final") ||' +
+            ' (MANDREL_VERSION=="master" && QUARKUS_VERSION=="master")')
+    parameters {
+        stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')
+    }
+    steps {
+        batchFile('''
+REM Prepare Mandrel
+@echo off
+call vcvars64
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+set BUILD_JOB=""
+IF "%MANDREL_VERSION%"=="20.2" (
+    set BUILD_JOB=mandrel-20.2-windows-build
+) ELSE IF "%MANDREL_VERSION%"=="20.3" (
+    set BUILD_JOB=mandrel-20.3-windows-build
+) ELSE IF "%MANDREL_VERSION%"=="master" (
+    set BUILD_JOB=mandrel-master-windows-build
+) ELSE (
+    echo "UNKNOWN Mandrel version: %MANDREL_VERSION%"
+    exit 1
+)
+
+set downloadCommand= ^
+$c = New-Object System.Net.WebClient; ^
+$url = 'https://ci.modcluster.io/view/Mandrel/job/%BUILD_JOB%/lastSuccessfulBuild/artifact/*zip*/archive.zip'; $file = 'archive.zip'; ^
+$c.DownloadFile($url, $file);
+powershell -Command "%downloadCommand%"
+
+powershell -c "Expand-Archive -Path archive.zip -DestinationPath . -Force"
+
+pushd archive
+
+for /f "tokens=5" %%g in ('dir mandrel-*.zip ^| findstr /R mandrel-.*.zip') do set ZIP_NAME=%%g
+
+powershell -c "Expand-Archive -Path %ZIP_NAME% -DestinationPath . -Force"
+echo ZIP_NAME: %ZIP_NAME%
+
+for /f "tokens=5" %%g in ('dir /AD mandrel-* ^| findstr /R mandrel-.*') do set GRAALVM_HOME=%cd%\\%%g
+echo GRAALVM_HOME: %GRAALVM_HOME%
+
+set "JAVA_HOME=%GRAALVM_HOME%"
+set "PATH=%JAVA_HOME%\\bin;%PATH%"
+
+if not exist "%GRAALVM_HOME%\\bin\\native-image.cmd" (
+  echo "Cannot find native-image tool. Quitting..."
+  exit 1
+) else (
+  echo "native-image.cmd is present, good."
+  cmd /C native-image --version
+)
+
+popd
+
+REM Prepare Quarkus
+git clone --depth 1 --branch %QUARKUS_VERSION% %QUARKUS_REPO%
+cd quarkus
+
+REM Build and test Quarkus
+
+set "MODULES=-pl !google-cloud-functions,!google-cloud-functions-http,!kubernetes/maven-invoker-way,!kubernetes-client"
+
+mvnw clean install -DskipTests -pl '!docs' & mvnw verify -f integration-tests/pom.xml --fail-at-end --batch-mode -DfailIfNoTests=false -Dnative %MODULES%
+
+        ''')
+    }
+    publishers {
+        archiveJunit('**/target/*-reports/*.xml') {
+            allowEmptyResults(false)
+            retainLongStdout(false)
+            healthScaleFactor(1.0)
+        }
+        archiveArtifacts('**/target/*-reports/*.xml')
+
+        extendedEmail {
+            recipientList('karm@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        wsCleanup()
+    }
+}

--- a/jenkins/jobs/scripts/mandrel_linux_build.sh
+++ b/jenkins/jobs/scripts/mandrel_linux_build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+pushd "${WORKSPACE}" || exit 1
+export MAVEN_REPO=${HOME}/.m2/repository
+export MANDREL_REPO=${WORKSPACE}/mandrel
+export JAVA_HOME=/usr/java/${OPENJDK}
+export MX_HOME=${WORKSPACE}/mx
+export PATH=${JAVA_HOME}/bin:${MX_HOME}:${PATH}
+pushd mandrel
+export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} $( git log --pretty=format:%h -n1)"
+export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
+export JAVA_VERSION="$(java --version | sed -e 's/.*build \([^) ]*\)).*/\1/;t;d' )"
+export MANDREL_HOME=${WORKSPACE}/mandrel-java11-${MANDREL_VERSION_UNTIL_SPACE}
+popd
+${JAVA_HOME}/bin/java -ea build.java --maven-local-repository ${MAVEN_REPO} \
+--mandrel-repo ${MANDREL_REPO} --mx-home ${MX_HOME} \
+--mandrel-version ${MANDREL_VERSION} --mandrel-home ${MANDREL_HOME} \
+--archive-suffix tar.gz
+TAR_NAME="$( ls mandrel-*.tar.gz )"
+sha1sum ${TAR_NAME}>${TAR_NAME}.sha1
+sha256sum ${TAR_NAME}>${TAR_NAME}.sha256
+cat >./MANDREL.md <<EOL
+This is a dev build of Mandrel from https://github.com/graalvm/mandrel.
+Mandrel ${MANDREL_VERSION}
+OpenJDK used: ${JAVA_VERSION}
+EOL
+if [[ ! -e "${MANDREL_HOME}/bin/native-image" ]]; then
+  echo "Cannot find native-image tool. Quitting..."
+  exit 1
+fi
+cat >./Hello.java <<EOL
+public class Hello {
+public static void main(String[] args) {
+    System.out.println("Hello.");
+}
+}
+EOL
+export JAVA_HOME=${MANDREL_HOME}
+export PATH=${JAVA_HOME}/bin:${PATH}
+javac Hello.java
+native-image Hello
+if [[ "`./hello`" == "Hello." ]]; then echo Done; else echo Native image fail;exit 1;fi

--- a/jenkins/jobs/scripts/mandrel_windows_build.bat
+++ b/jenkins/jobs/scripts/mandrel_windows_build.bat
@@ -1,0 +1,76 @@
+@echo off
+
+pushd %WORKSPACE%
+
+set PYTHONHTTPSVERIFY=0
+set "JAVA_HOME=C:\Program Files\AdoptOpenJDK\%OPENJDK%"
+set "PATH=%JAVA_HOME%\bin;%PATH%"
+set MAVEN_REPO=C:\tmp\.m2\repository
+set "MANDREL_REPO=%WORKSPACE%\mandrel"
+set "MX_HOME=%WORKSPACE%\mx"
+
+pushd mandrel
+for /F "tokens=*" %%i in ('"git log --pretty=format:%%h -n1"') do set VER=%%i
+set "MANDREL_VERSION=%MANDREL_VERSION_SUBSTRING% %VER%"
+for /f "tokens=1 delims= " %%a IN ("%MANDREL_VERSION%") do set MANDREL_VERSION_UNTIL_SPACE=%%a
+for /f "tokens=6" %%g in ('java --version 2^>^&1 ^| findstr /R "Runtime.*build "') do set JAVA_VERSION=%%g
+set JAVA_VERSION=%JAVA_VERSION:~0,-1%
+set MANDREL_HOME=%WORKSPACE%\mandrel-java11-%MANDREL_VERSION_UNTIL_SPACE%
+popd
+
+echo XXX MANDREL_VERSION_SUBSTRING: %MANDREL_VERSION_SUBSTRING%
+echo XXX MANDREL_VERSION: %MANDREL_VERSION%
+echo XXX MANDREL_VERSION_UNTIL_SPACE: %MANDREL_VERSION_UNTIL_SPACE%
+echo XXX JAVA_VERSION: %JAVA_VERSION%
+echo XXX MANDREL_HOME: %MANDREL_HOME%
+echo XXX MX_HOME: %MX_HOME%
+echo XXX MAVEN_REPO: %MAVEN_REPO%
+echo XXX MANDREL_REPO: %MANDREL_REPO%
+echo XXX JAVA_HOME: %JAVA_HOME%
+
+call vcvars64
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+"%JAVA_HOME%\bin\java" -ea build.java --maven-local-repository "%MAVEN_REPO%" --mandrel-repo "%MANDREL_REPO%" --mx-home "%MX_HOME%" --mandrel-version "%MANDREL_VERSION%" --mandrel-home "%MANDREL_HOME%" --archive-suffix zip
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+for /f "tokens=5" %%g in ('dir mandrel-*.zip ^| findstr /R mandrel-.*.zip') do set ZIP_NAME=%%g
+powershell -c "$hash=(Get-FileHash %ZIP_NAME% -Algorithm SHA1).Hash;echo \"$hash %ZIP_NAME%\"">%ZIP_NAME%.sha1
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+powershell -c "$hash=(Get-FileHash %ZIP_NAME% -Algorithm SHA256).Hash;echo \"$hash %ZIP_NAME%\"">%ZIP_NAME%.sha256
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+(
+echo This is a dev build of Mandrel from https://github.com/graalvm/mandrel.
+echo Mandrel %MANDREL_VERSION%
+echo OpenJDK used: %JAVA_VERSION%
+) >MANDREL.md
+
+if not exist "%MANDREL_HOME%\bin\native-image.cmd" (
+  echo "Cannot find native-image tool. Quitting..."
+  exit 1
+) else (
+  echo "native-image.cmd is present, good."
+)
+
+(
+echo|set /p=" public class Hello {"
+echo|set /p=" public static void main(String[] args) {"
+echo|set /p="     System.out.println("Hello.");"
+echo|set /p=" }"
+echo|set /p=" }"
+) >Hello.java
+
+set "JAVA_HOME=%MANDREL_HOME%"
+set "PATH=%JAVA_HOME%\bin;%PATH%"
+javac Hello.java
+native-image Hello
+
+for /F "tokens=*" %%i in ('hello.exe') do set HELLO_OUT=%%i
+if "%HELLO_OUT%" == "Hello." (
+  echo Done
+) else (
+  echo Native image fail
+  exit 1
+)


### PR DESCRIPTION
How one works with it:
1. Do a change in jenkins/*, have it merged.
2. Click build now on this job https://ci.modcluster.io/view/Mandrel/job/dsl-mandrel-jobs/
3. It fails the first time, because your changes are pending script approval; Open https://ci.modcluster.io/scriptApproval/ and approve
4. Run step 2. again and it is all regenerated as one would expect.

Ad step 3.: I am investigating if it is really necessary and what additional security it actually brings.

Readme/docs on the syntax: https://ci.modcluster.io//plugin/job-dsl/api-viewer/index.html