### PR TITLE
Jenkins DSL: Add 21.0 to the matrix

### DIFF
--- a/jenkins/jobs/mandrel_21_0_linux_build.groovy
+++ b/jenkins/jobs/mandrel_21_0_linux_build.groovy
@@ -1,0 +1,140 @@
+job('mandrel-21.0-linux-build') {
+    label 'el8'
+    displayName('Linux Build :: 21.0')
+    description('''
+Linux build for 21.0 branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'mandrel/21.0',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9.1_1',
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                'master',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                '21.0-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        shell('echo MANDREL_VERSION_SUBSTRING=${MANDREL_VERSION_SUBSTRING}')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        shell('./jenkins/jobs/scripts/mandrel_linux_build.sh')
+    }
+    publishers {
+        archiveArtifacts('*.tar.gz,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-linux-quarkus-tests/LABEL=el8,MANDREL_VERSION=21.0,QUARKUS_VERSION=1.11.0.Final/',
+                     'mandrel-linux-integration-tests/MANDREL_VERSION=21.0,label=el8']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_21_0_windows_build.groovy
+++ b/jenkins/jobs/mandrel_21_0_windows_build.groovy
@@ -1,0 +1,140 @@
+job('mandrel-21.0-windows-build') {
+    label 'w2k19'
+    displayName('Windows Build :: 21.0')
+    description('''
+Windows build for 21.0 branch.
+    ''')
+    logRotator {
+        numToKeep(5)
+    }
+    parameters {
+        choiceParam(
+                'REPOSITORY',
+                [
+                        'https://github.com/graalvm/mandrel.git',
+                        'https://github.com/jerboaa/graal.git',
+                        'https://github.com/Karm/graal.git',
+                        'https://github.com/zakkak/mandrel.git',
+                ],
+                'Mandrel repo'
+        )
+        choiceParam(
+                'HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'BRANCH_OR_TAG',
+                'mandrel/21.0',
+                'e.g. your PR branch or a specific tag.'
+        )
+        choiceParam(
+                'OPENJDK',
+                [
+                        'openjdk-11.0.9.1_1',
+                        'openjdk-11.0.9_11',
+                        'openjdk-11-ea',
+                        'openjdk-11-latest'
+
+                ],
+                'OpenJDK including Static libs'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY',
+                [
+                        'https://github.com/mandrel/mandrel-packaging.git',
+                        'https://github.com/Karm/mandrel-packaging.git',
+                        'https://github.com/zakkak/mandrel-packaging.git'
+                ],
+                'Mandrel packaging scripts.'
+        )
+        choiceParam(
+                'PACKAGING_REPOSITORY_HEADS_OR_TAGS',
+                [
+                        'heads',
+                        'tags',
+
+                ],
+                'To be used with the repository, e.g. to use a certain head or a tag.'
+        )
+        stringParam(
+                'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
+                'master',
+                'e.g. master if you use heads or some tag if you use tags.'
+        )
+        stringParam(
+                'MANDREL_VERSION_SUBSTRING',
+                '21.0-SNAPSHOT',
+                '''Used as a part of Mandrel version, i.e. <pre>export MANDREL_VERSION="${MANDREL_VERSION_SUBSTRING} 
+git rev.: $( git log --pretty=format:%h -n1 ) </pre> it defaults to <pre>${BRANCH_OR_TAG}</pre>. 
+Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarball name too.'''
+        )
+    }
+    multiscm {
+        git {
+            remote {
+                url('${PACKAGING_REPOSITORY}')
+            }
+            branches('refs/${PACKAGING_REPOSITORY_HEADS_OR_TAGS}/${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${PACKAGING_REPOSITORY_BRANCH_OR_TAG}')
+            }
+        }
+        git {
+            remote {
+                url('${REPOSITORY}')
+            }
+            branches('refs/${HEADS_OR_TAGS}/${BRANCH_OR_TAG}')
+            extensions {
+                localBranch('${BRANCH_OR_TAG}')
+                relativeTargetDirectory('mandrel')
+            }
+        }
+        git {
+            remote {
+                url('https://github.com/graalvm/mx.git')
+            }
+            branches('*/master')
+            extensions {
+                localBranch('master')
+                relativeTargetDirectory('mx')
+            }
+        }
+    }
+    triggers {
+        scm('H H/2 * * *')
+    }
+    steps {
+        batchFile('echo MANDREL_VERSION_SUBSTRING=%MANDREL_VERSION_SUBSTRING%')
+        buildDescription(/MANDREL_VERSION_SUBSTRING=([^\s]*)/, '\\1')
+        batchFile('cmd /C jenkins\\jobs\\scripts\\mandrel_windows_build.bat')
+    }
+    publishers {
+        archiveArtifacts('*.zip,MANDREL.md,*.sha1,*.sha256')
+        wsCleanup()
+        extendedEmail {
+            recipientList('karm@redhat.com,fzakkak@redhat.com')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        attachBuildLog(true)
+                    }
+                }
+            }
+        }
+        downstreamParameterized {
+            trigger(['mandrel-windows-quarkus-tests/LABEL=w2k19,MANDREL_VERSION=21.0,QUARKUS_VERSION=1.11.0.Final/',
+                     'mandrel-windows-integration-tests/MANDREL_VERSION=21.0,label=w2k19/']) {
+                condition('SUCCESS')
+                parameters {
+                    currentBuild()
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/mandrel_linux_integration_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_integration_tests.groovy
@@ -2,8 +2,8 @@ matrixJob('mandrel-linux-integration-tests') {
     axes {
         text('MANDREL_VERSION',
                 '20.1',
-                '20.2',
                 '20.3',
+                '21.0',
                 'master'
         )
         labelExpression('label', ['el8'])
@@ -43,8 +43,8 @@ matrixJob('mandrel-linux-integration-tests') {
         shell('''
             case $MANDREL_VERSION in
                 20.1)    BUILD_JOB='mandrel-20.1-linux-build';;
-                20.2)    BUILD_JOB='mandrel-20.2-linux-build';;
                 20.3)    BUILD_JOB='mandrel-20.3-linux-build';;
+                21.0)    BUILD_JOB='mandrel-21.0-linux-build';;
                 master)  BUILD_JOB='mandrel-master-linux-build';;
                 *)
                     echo "UNKNOWN Mandrel version: $MANDREL_VERSION"

--- a/jenkins/jobs/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_quarkus_tests.groovy
@@ -3,6 +3,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
         text('MANDREL_VERSION',
                 '20.1',
                 '20.3',
+                '21.0',
                 'master'
         )
         text('QUARKUS_VERSION',
@@ -24,7 +25,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
         }
     }
     combinationFilter('(MANDREL_VERSION=="20.1" && QUARKUS_VERSION=="1.7.6.Final") ||' +
-            ' ((MANDREL_VERSION=="20.3" || MANDREL_VERSION=="master") && QUARKUS_VERSION=="1.11.0.Final")')
+            ' ((MANDREL_VERSION=="20.3" || MANDREL_VERSION=="21.0" || MANDREL_VERSION=="master") && QUARKUS_VERSION=="1.11.0.Final")')
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')
     }
@@ -34,6 +35,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
             case $MANDREL_VERSION in
                 20.1)    BUILD_JOB='mandrel-20.1-linux-build';;
                 20.3)    BUILD_JOB='mandrel-20.3-linux-build';;
+                21.0)    BUILD_JOB='mandrel-21.0-linux-build';;
                 master)  BUILD_JOB='mandrel-master-linux-build';;
                 *)
                     echo "UNKNOWN Mandrel version: $MANDREL_VERSION"

--- a/jenkins/jobs/mandrel_windows_integration_tests.groovy
+++ b/jenkins/jobs/mandrel_windows_integration_tests.groovy
@@ -1,8 +1,8 @@
 matrixJob('mandrel-windows-integration-tests') {
     axes {
         text('MANDREL_VERSION',
-                '20.2',
                 '20.3',
+                '21.0',
                 'master'
         )
         labelExpression('label', ['w2k19'])
@@ -45,8 +45,8 @@ call vcvars64
 IF NOT %ERRORLEVEL% == 0 ( exit 1 )
 
 set BUILD_JOB=""
-IF "%MANDREL_VERSION%"=="20.2" (
-    set BUILD_JOB=mandrel-20.2-windows-build
+IF "%MANDREL_VERSION%"=="21.0" (
+    set BUILD_JOB=mandrel-21.0-windows-build
 ) ELSE IF "%MANDREL_VERSION%"=="20.3" (
     set BUILD_JOB=mandrel-20.3-windows-build
 ) ELSE IF "%MANDREL_VERSION%"=="master" (


### PR DESCRIPTION
Adds version 21.0 to the matrix removing 20.2 from tests.
