### PR TITLE
Jenkins: Reduce build steps run by maven container testing

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -3,11 +3,13 @@ name: Test Ansible playbook
 on:
   push:
     paths-ignore:
+      - 'jenkins/**'
       - 'cekit/**'
       - 'README.md'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
+      - 'jenkins/**'
       - 'cekit/**'
       - 'README.md'
 

--- a/jenkins/jobs/mandrel_linux_quarkus_container_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_quarkus_container_tests.groovy
@@ -51,7 +51,7 @@ job('mandrel-linux-quarkus-container-tests') {
             fi
             
             # Build Quarkus
-            ./mvnw clean install -DskipTests -pl '!docs'
+            ./mvnw -Dquickly
             
             # Test Quarkus
             export MODULES="-pl \\
@@ -59,7 +59,7 @@ job('mandrel-linux-quarkus-container-tests') {
 !maven"
             
             ./mvnw verify -f integration-tests/pom.xml --fail-at-end \\
-   ${MODULES} -Dno-format -Ddocker -Dnative \\
+   ${MODULES} -Dno-format -Ddocker -Dnative -Dnative.surefire.skip \\
   -Dquarkus.native.container-build=true \\
   -Dquarkus.native.builder-image="${CONTAINER_IMAGE}" \\
   -Dquarkus.native.container-runtime=${CONTAINER_RUNTIME}


### PR DESCRIPTION
This should speed up our testing a bit.
`-Dquickly` enables:
```
        <profile>
            <id>quick-build</id>
            <activation>
                <property>
                    <name>quickly</name>
                </property>
            </activation>
            <properties>
                <!-- please check quick-build-ci as well when modifying these properties -->
                <skipTests>true</skipTests>
                <skipITs>true</skipITs>
                <skipDocs>true</skipDocs>
                <enforcer.skip>true</enforcer.skip>
                <format.skip>true</format.skip>
                <skipExtensionValidation>true</skipExtensionValidation>
                <skip.gradle.tests>true</skip.gradle.tests>
                <invoker.skip>true</invoker.skip>   <!-- maven-invoker-plugin -->
                <jbang.skip>true</jbang.skip> <!-- jbang-maven-plugin -->
            </properties>
            <build>
                <defaultGoal>clean install</defaultGoal>
            </build>
        </profile>
```

and `-Dnative.surefire.skip` skips any JVM-mode tests and runs only the native ones.