### PR TITLE
JDK updates, Q update

### DIFF
--- a/jenkins/jobs/graal_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/graal_windows_quarkus_tests.groovy
@@ -4,7 +4,7 @@ matrixJob('graal-windows-quarkus-tests') {
                 '20.3.1',
         )
         text('QUARKUS_VERSION',
-                '1.11.3.Final',
+                '1.11.5.Final',
                 'master'
         )
         labelExpression('LABEL', ['w2k19'])

--- a/jenkins/jobs/mandrel_20_1_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_1_linux_build.groovy
@@ -35,8 +35,8 @@ Linux build for 20.1 branch.
         choiceParam(
                 'OPENJDK',
                 [
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
 

--- a/jenkins/jobs/mandrel_20_3_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_linux_build.groovy
@@ -35,8 +35,8 @@ Linux build for 20.3 branch.
         choiceParam(
                 'OPENJDK',
                 [
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
 

--- a/jenkins/jobs/mandrel_20_3_windows_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_windows_build.groovy
@@ -35,8 +35,8 @@ Windows build for 20.3 branch.
         choiceParam(
                 'OPENJDK',
                 [
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
 

--- a/jenkins/jobs/mandrel_21_0_linux_build.groovy
+++ b/jenkins/jobs/mandrel_21_0_linux_build.groovy
@@ -35,8 +35,8 @@ Linux build for 21.0 branch.
         choiceParam(
                 'OPENJDK',
                 [
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
 

--- a/jenkins/jobs/mandrel_21_0_windows_build.groovy
+++ b/jenkins/jobs/mandrel_21_0_windows_build.groovy
@@ -35,8 +35,8 @@ Windows build for 21.0 branch.
         choiceParam(
                 'OPENJDK',
                 [
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
 

--- a/jenkins/jobs/mandrel_linux_quarkus_container_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_quarkus_container_tests.groovy
@@ -19,8 +19,8 @@ job('mandrel-linux-quarkus-container-tests') {
         choiceParam(
                 'OPENJDK',
                 [
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
 

--- a/jenkins/jobs/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/mandrel_linux_quarkus_tests.groovy
@@ -7,7 +7,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
                 'master'
         )
         text('QUARKUS_VERSION',
-                '1.11.3.Final',
+                '1.11.5.Final',
                 '1.7.6.Final',
                 'master'
         )
@@ -26,7 +26,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
         }
     }
     combinationFilter('(MANDREL_VERSION=="20.1" && QUARKUS_VERSION=="1.7.6.Final") ||' +
-            ' (MANDREL_VERSION=="20.3" && QUARKUS_VERSION=="1.11.3.Final") ||' +
+            ' (MANDREL_VERSION=="20.3" && QUARKUS_VERSION=="1.11.5.Final") ||' +
             ' ((MANDREL_VERSION=="21.0" || MANDREL_VERSION=="master") && QUARKUS_VERSION=="master")')
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')

--- a/jenkins/jobs/mandrel_master_linux_build.groovy
+++ b/jenkins/jobs/mandrel_master_linux_build.groovy
@@ -35,8 +35,8 @@ Linux build for master branch.
         choiceParam(
                 'OPENJDK',
                 [
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
                 ],

--- a/jenkins/jobs/mandrel_master_linux_build_labsjdk.groovy
+++ b/jenkins/jobs/mandrel_master_linux_build_labsjdk.groovy
@@ -36,8 +36,8 @@ Linux build for master branch with LabsJDK
                 'OPENJDK',
                 [
                         'labsjdk-ce-11',
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
 

--- a/jenkins/jobs/mandrel_master_windows_build.groovy
+++ b/jenkins/jobs/mandrel_master_windows_build.groovy
@@ -35,8 +35,8 @@ Windows build for master branch.
         choiceParam(
                 'OPENJDK',
                 [
+                        'openjdk-11.0.11_4',
                         'openjdk-11.0.10_9',
-                        'openjdk-11.0.9.1_1',
                         'openjdk-11-ea',
                         'openjdk-11'
 

--- a/jenkins/jobs/mandrel_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/mandrel_windows_quarkus_tests.groovy
@@ -6,7 +6,7 @@ matrixJob('mandrel-windows-quarkus-tests') {
                 'master'
         )
         text('QUARKUS_VERSION',
-                '1.11.3.Final',
+                '1.11.5.Final',
                 'master'
         )
         labelExpression('LABEL', ['w2k19'])
@@ -23,7 +23,7 @@ matrixJob('mandrel-windows-quarkus-tests') {
             absolute(720)
         }
     }
-    combinationFilter(' (MANDREL_VERSION=="20.3" && QUARKUS_VERSION=="1.11.3.Final") ||' +
+    combinationFilter(' (MANDREL_VERSION=="20.3" && QUARKUS_VERSION=="1.11.5.Final") ||' +
             ' ((MANDREL_VERSION=="21.0" || MANDREL_VERSION=="master") && QUARKUS_VERSION=="master")')
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')


### PR DESCRIPTION
Hello @zakkak,  JDKs on test hosts are updated to:

```
Linux:
/usr/java:
    graalvm-ce-java11 -> /usr/java/graalvm-ce-java11-21.0.0.2
    graalvm-ce-java11-20.1.0
    graalvm-ce-java11-20.3.1.2
    graalvm-ce-java11-21.0.0.2
    labsjdk-ce-11 -> /usr/java/labsjdk-ce-11.0.10-jvmci-21.1-b01-debug
    labsjdk-ce-11.0.10-jvmci-21.1-b01-debug
    openjdk-11 -> /usr/java/openjdk-11.0.10_9
    openjdk-11.0.10_9
    openjdk-11.0.11_4
    openjdk-11-ea -> /usr/java/openjdk-11.0.11_4
    openjdk-8 -> /usr/java/openjdk-8u282-b08
    openjdk-8u282-b08

Windows:
 Directory of C:\Program Files

<SYMLINKD>     graalvm-ce-java11 [C:\Program Files\graalvm-ce-java11-21.0.0.2]
<DIR>          graalvm-ce-java11-20.1.0
<DIR>          graalvm-ce-java11-20.3.1.2
<DIR>          graalvm-ce-java11-21.0.0.2
<DIR>          labsjdk-ce-11.0.10-jvmci-21.1-b01-debug
<SYMLINKD>     openjdk-11 [C:\Program Files\openjdk-11.0.10_9]
<SYMLINKD>     openjdk-11-ea [C:\Program Files\openjdk-11.0.11_4]
<DIR>          openjdk-11.0.10_9
<DIR>          openjdk-11.0.11_4
<SYMLINKD>     openjdk-8 [C:\Program Files\openjdk-8u282-b08]
<DIR>          openjdk-8u282-b08
```
