### PR TITLE
Jenkins: Pin mx version for 20.1, 20.3, and 21.0 builds

### DIFF
--- a/jenkins/jobs/mandrel_20_1_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_1_linux_build.groovy
@@ -98,9 +98,9 @@ Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarba
             remote {
                 url('https://github.com/graalvm/mx.git')
             }
-            branches('*/master')
+            branches('refs/tags/5.259.0')
             extensions {
-                localBranch('master')
+                localBranch('5.259.0')
                 relativeTargetDirectory('mx')
             }
         }

--- a/jenkins/jobs/mandrel_20_3_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_linux_build.groovy
@@ -98,9 +98,9 @@ Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarba
             remote {
                 url('https://github.com/graalvm/mx.git')
             }
-            branches('*/master')
+            branches('refs/tags/5.273.0')
             extensions {
-                localBranch('master')
+                localBranch('5.273.0')
                 relativeTargetDirectory('mx')
             }
         }

--- a/jenkins/jobs/mandrel_20_3_windows_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_windows_build.groovy
@@ -98,9 +98,9 @@ Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarba
             remote {
                 url('https://github.com/graalvm/mx.git')
             }
-            branches('*/master')
+            branches('refs/tags/5.273.0')
             extensions {
-                localBranch('master')
+                localBranch('5.273.0')
                 relativeTargetDirectory('mx')
             }
         }

--- a/jenkins/jobs/mandrel_21_0_linux_build.groovy
+++ b/jenkins/jobs/mandrel_21_0_linux_build.groovy
@@ -98,9 +98,9 @@ Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarba
             remote {
                 url('https://github.com/graalvm/mx.git')
             }
-            branches('*/master')
+            branches('refs/tags/5.279.1')
             extensions {
-                localBranch('master')
+                localBranch('5.279.1')
                 relativeTargetDirectory('mx')
             }
         }

--- a/jenkins/jobs/mandrel_21_0_windows_build.groovy
+++ b/jenkins/jobs/mandrel_21_0_windows_build.groovy
@@ -98,9 +98,9 @@ Could be e.g. 20.1.0.0.Alpha1. It must not contain spaces as it is used in tarba
             remote {
                 url('https://github.com/graalvm/mx.git')
             }
-            branches('*/master')
+            branches('refs/tags/5.279.1')
             extensions {
-                localBranch('master')
+                localBranch('5.279.1')
                 relativeTargetDirectory('mx')
             }
         }


### PR DESCRIPTION
This way we avoid rebuilding each time mx master gets updated