### PR TITLE
Use specific mandrel-packaging branch for 20.3 and 21.0

### DIFF
--- a/jenkins/jobs/mandrel_20_3_linux_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_linux_build.groovy
@@ -63,7 +63,7 @@ Linux build for 20.3 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                'master',
+                '20.3',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(

--- a/jenkins/jobs/mandrel_20_3_windows_build.groovy
+++ b/jenkins/jobs/mandrel_20_3_windows_build.groovy
@@ -63,7 +63,7 @@ Windows build for 20.3 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                'master',
+                '20.3',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(

--- a/jenkins/jobs/mandrel_21_0_linux_build.groovy
+++ b/jenkins/jobs/mandrel_21_0_linux_build.groovy
@@ -63,7 +63,7 @@ Linux build for 21.0 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                'master',
+                '21.0',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(

--- a/jenkins/jobs/mandrel_21_0_windows_build.groovy
+++ b/jenkins/jobs/mandrel_21_0_windows_build.groovy
@@ -63,7 +63,7 @@ Windows build for 21.0 branch.
         )
         stringParam(
                 'PACKAGING_REPOSITORY_BRANCH_OR_TAG',
-                'master',
+                '21.0',
                 'e.g. master if you use heads or some tag if you use tags.'
         )
         stringParam(


### PR DESCRIPTION
https://github.com/graalvm/mandrel-packaging/pull/112 breaks 20.3 and 21.0 builds with `master`