### PR TITLE
Remove parentheses from graalvm config

### DIFF
--- a/build.java
+++ b/build.java
@@ -257,7 +257,7 @@ public class build
                 StringBuilder launcherLine = new StringBuilder(lines.get(i).length() * 2);
                 launcherLine.append(launcherMatcher.group(1));
                 launcherLine.append(" -Dorg.graalvm.version=\"" + mandrelVersion + "\"");
-                launcherLine.append(" -Dorg.graalvm.config=\"(Mandrel Distribution)\"");
+                launcherLine.append(" -Dorg.graalvm.config=\"Mandrel Distribution\"");
                 if (IS_WINDOWS)
                 {
                     launcherLine.append(" --upgrade-module-path \"%location%\\..\\..\\jvmci\\graal.jar\"");


### PR DESCRIPTION
Make `native-image --version` print:
```
native-image 21.1.0.0-Final Java 11 Mandrel Distribution (Java Version 11.0.10+9)
```
when `native-image` is a bash launcher and
```
GraalVM 21.1.0.0-Final Java 11 Mandrel Distribution (Java Version 11.0.10+9)
```
when `native-image` is a binary.

Relates to https://github.com/oracle/graal/pull/3329
Closes: https://github.com/graalvm/mandrel/issues/230