### PR TITLE
HACK: work-around windows build failure

### DIFF
--- a/build.java
+++ b/build.java
@@ -786,10 +786,13 @@ class Mx
             "truffle:TRUFFLE_API",
             "com.oracle.svm.truffle.nfi",
             "com.oracle.svm.truffle.nfi.posix",
-            "com.oracle.svm.truffle.nfi.windows",
             "extracted-dependency:truffle:LIBFFI_DIST",
             "extracted-dependency:truffle:TRUFFLE_NFI_NATIVE/include/*",
             "file:src/com.oracle.svm.libffi/include/svm_libffi.h");
+        if (!build.IS_WINDOWS)
+        {
+            dependencies.add("com.oracle.svm.truffle.nfi.windows");
+        }
         Tasks.FileReplace.replace(
             new Tasks.FileReplace(path, removeDependencies(dependencies))
             , effects


### PR DESCRIPTION
https://github.com/oracle/graal/commit/
75dd818a142ad57b41d4d7dd43bd8f64d8184d44
seems to break Mandrel windows builds

The builds fail with:
dependency named native-image-agent.dll.image was removed:
  removed native-image-agent.dll.image because
  GRAALVM_70ED04E3E5_JAVA11_STAGE1 was removed

which is caused due to:
[distribution SVM_LIBFFI was removed as all its dependencies were
removed]
[removed GRAALVM_70ED04E3E5_JAVA11_STAGE1 because SVM_LIBFFI was
removed]

This PR avoids removing the com.oracle.svm.truffle.nfi.windows
dependency on Windows builds so that SVM_LIBFFI won't get removed.