### PR TITLE
Remove newly added truffle dependencies & update jvmti-agent-base location

### DIFF
--- a/build.java
+++ b/build.java
@@ -1059,6 +1059,7 @@ class Maven
         , "jvmti-agent-base"
         , "svm-agent"
         , "svm-diagnostics-agent"
+        , "svm-configure"
     );
 
     static final String INSTALL_FILE_VERSION = "2.4";
@@ -1086,7 +1087,8 @@ class Maven
         new SimpleEntry<>("svm-driver", "org.graalvm.nativeimage"),
         new SimpleEntry<>("jvmti-agent-base", "org.graalvm.nativeimage"),
         new SimpleEntry<>("svm-agent", "org.graalvm.nativeimage"),
-        new SimpleEntry<>("svm-diagnostics-agent", "org.graalvm.nativeimage")
+        new SimpleEntry<>("svm-diagnostics-agent", "org.graalvm.nativeimage"),
+        new SimpleEntry<>("svm-configure", "org.graalvm.nativeimage")
     );
 
     static final Map<String, Path> DISTS_PATHS = Map.ofEntries(
@@ -1100,7 +1102,8 @@ class Maven
         new SimpleEntry<>("svm-driver", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-driver")),
         new SimpleEntry<>("jvmti-agent-base", Path.of("substratevm", "mxbuild", "dists", "jdk11", "jvmti-agent-base")),
         new SimpleEntry<>("svm-agent", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-agent")),
-        new SimpleEntry<>("svm-diagnostics-agent", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-diagnostics-agent"))
+        new SimpleEntry<>("svm-diagnostics-agent", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-diagnostics-agent")),
+        new SimpleEntry<>("svm-configure", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-configure"))
     );
 
     static final Map<String, Path> JDK_PATHS = Map.ofEntries(
@@ -1114,7 +1117,8 @@ class Maven
         new SimpleEntry<>("svm-driver", Path.of("lib", "graalvm", "svm-driver")),
         new SimpleEntry<>("jvmti-agent-base", Path.of("lib", "graalvm", "jvmti-agent-base")),
         new SimpleEntry<>("svm-agent", Path.of("lib", "graalvm", "svm-agent")),
-        new SimpleEntry<>("svm-diagnostics-agent", Path.of("lib", "graalvm", "svm-diagnostics-agent"))
+        new SimpleEntry<>("svm-diagnostics-agent", Path.of("lib", "graalvm", "svm-diagnostics-agent")),
+        new SimpleEntry<>("svm-configure", Path.of("lib", "graalvm", "svm-configure"))
     );
 
     final Path mvn;

--- a/build.java
+++ b/build.java
@@ -799,6 +799,9 @@ class Mx
         final List<String> dependencies = Arrays.asList(
             "truffle:TRUFFLE_NFI",
             "com.oracle.svm.truffle",
+            "com.oracle.svm.truffle.api                   to org.graalvm.truffle",
+            "com.oracle.truffle.api.TruffleLanguage.Provider",
+            "com.oracle.truffle.api.instrumentation.TruffleInstrument.Provider",
             "com.oracle.svm.polyglot",
             "truffle:TRUFFLE_API",
             "com.oracle.svm.truffle.nfi",
@@ -1095,9 +1098,9 @@ class Maven
         new SimpleEntry<>("compiler", Path.of("compiler", "mxbuild", "dists", "jdk11", "graal")),
         new SimpleEntry<>("objectfile", Path.of("substratevm", "mxbuild", "dists", "jdk11", "objectfile")),
         new SimpleEntry<>("svm-driver", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-driver")),
-        new SimpleEntry<>("jvmti-agent-base", Path.of("substratevm", "mxbuild", "dists", "jdk1.8", "jvmti-agent-base")),
+        new SimpleEntry<>("jvmti-agent-base", Path.of("substratevm", "mxbuild", "dists", "jdk11", "jvmti-agent-base")),
         new SimpleEntry<>("svm-agent", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-agent")),
-        new SimpleEntry<>("svm-diagnostics-agent", Path.of("substratevm", "mxbuild", "dists", "jdk1.8", "svm-diagnostics-agent"))
+        new SimpleEntry<>("svm-diagnostics-agent", Path.of("substratevm", "mxbuild", "dists", "jdk11", "svm-diagnostics-agent"))
     );
 
     static final Map<String, Path> JDK_PATHS = Map.ofEntries(


### PR DESCRIPTION
https://github.com/oracle/graal/commit/1e639c93bdd56031fffc8b45f48bde3ec4f6fb11 introduces some more dependencies on Truffle that Mandrel doesn't really depend on

https://github.com/oracle/graal/commit/d81403ae7725610dc809b1d9a61797b15f5632de change the location of the jvmti-agent-base.jar

Both changes were part of https://github.com/oracle/graal/pull/3446
