### PR TITLE
Fix two step builds 21.2

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/21.2]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/checkout@v2
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/21.2]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/checkout@v2
@@ -230,3 +230,84 @@ jobs:
       with:
         name: mandrel-java11-windows-amd64-test-build
         path: mandrel-java11-windows-amd64.zip
+
+  build-and-test-2-step:
+    name: 2-step Linux Build and test ${{ matrix.mandrel-ref }} branch/tag
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mandrel-ref: [mandrel/21.2]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        repository: graalvm/mandrel.git
+        fetch-depth: 1
+        ref: ${{ matrix.mandrel-ref }}
+        path: ${{ github.workspace }}/mandrel
+    - uses: actions/checkout@v2
+      with:
+        repository: graalvm/mx.git
+        fetch-depth: 1
+        ref: master
+        path: ${{ github.workspace }}/mx
+    - uses: actions/cache@v2.1.5
+      with:
+        path: ~/.mx
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: |
+          ${{ runner.os }}-mx-
+    - uses: actions/cache@v2.1.5
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
+    - name: Get latest openJDK11 with static libs
+      run: |
+        curl -sL https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/openjdk -o jdk.tar.gz
+        curl -sL https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/staticlibs/hotspot/normal/openjdk -o jdk-static-libs.tar.gz
+        mkdir -p ${JAVA_HOME}
+        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
+        tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+        echo ${JAVA_HOME}
+        ${JAVA_HOME}/bin/java --version
+    - name: Build Mandrel JDK
+      run: |
+        # Build the Java bits
+        ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --skip-native --mandrel-home temp-build
+        # Build the native bits
+        ./temp-build/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --skip-java --archive-suffix tar.gz
+        export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
+        export ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java11-linux-amd64.tar.gz
+    - name: Smoke tests
+      run: |
+        export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
+        export MANDREL_HOME=${PWD}/mandrel-java11-${MANDREL_VERSION_UNTIL_SPACE}
+        ${MANDREL_HOME}/bin/native-image --version
+        ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
+        echo "
+        public class HelloStrict {
+            public static void main(String[] args) {
+                System.out.printf(
+                    \"Hello %1$,.12f %2$,.12f %3$,.12f %n\"
+                    , StrictMath.cos(0.0)
+                    , StrictMath.IEEEremainder(3.0, 5.0)
+                    , StrictMath.IEEEremainder(-16.3, 4.1)
+                );
+            }
+        }
+        " > HelloStrict.java
+        ${MANDREL_HOME}/bin/javac HelloStrict.java
+        ${MANDREL_HOME}/bin/java HelloStrict | tee java.txt
+        ${MANDREL_HOME}/bin/native-image HelloStrict
+        ./hellostrict | tee native.txt
+        diff java.txt native.txt
+        ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
+    - name: Upload Mandrel build
+      uses: actions/upload-artifact@v1
+      with:
+        name: mandrel-java11-linux-amd64-2step-test-build
+        path: mandrel-java11-linux-amd64.tar.gz

--- a/ansible/configurations/default-openjdk.yml
+++ b/ansible/configurations/default-openjdk.yml
@@ -1,5 +1,5 @@
 mx_version: "master"
-mandrel_version: "graal/master"
+mandrel_version: "mandrel/21.2"
 jdk_urls:
   - https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/openjdk
   - https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/staticlibs/hotspot/normal/openjdk


### PR DESCRIPTION
Fixes:

```
Exception in thread "main" java.lang.IllegalAccessError: class com.oracle.svm.util.ModuleSupport (in module org.graalvm.nativeimage.pointsto) cannot access class jdk.internal.module.Modules (in module java.base) because module java.base does not export jdk.internal.module to module org.graalvm.nativeimage.pointsto
	at org.graalvm.nativeimage.pointsto/com.oracle.svm.util.ModuleSupport.openModuleByClass(ModuleSupport.java:143)
	at org.graalvm.nativeimage.pointsto/com.oracle.svm.util.ReflectionUtil.openModule(ReflectionUtil.java:53)
	at org.graalvm.nativeimage.pointsto/com.oracle.svm.util.ReflectionUtil.lookupConstructor(ReflectionUtil.java:81)
	at org.graalvm.nativeimage.pointsto/com.oracle.svm.util.ReflectionUtil.lookupConstructor(ReflectionUtil.java:75)
	at org.graalvm.nativeimage.pointsto/com.oracle.svm.util.ReflectionUtil.newInstance(ReflectionUtil.java:94)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.APIOptionHandler.extractOption(APIOptionHandler.java:230)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.APIOptionHandler.lambda$extractOptions$0(APIOptionHandler.java:121)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.APIOptionHandler.extractOptions(APIOptionHandler.java:121)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.APIOptionHandler.<init>(APIOptionHandler.java:110)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.<init>(NativeImage.java:774)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.lambda$static$23(NativeImage.java:1529)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.build(NativeImage.java:1562)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.performBuild(NativeImage.java:1545)
	at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.main(NativeImage.java:1532)
Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: Failed, exit code: 1
	at OperatingSystem.exec(build.java:1694)
	at build.buildAgents(build.java:182)
	at build.main(build.java:164)
Caused by: java.lang.RuntimeException: Failed, exit code: 1
	at OperatingSystem.exec(build.java:1679)
	at build.buildAgents(build.java:182)
	at build.main(build.java:164)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.execute(Main.java:404)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.run(Main.java:179)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:119)
```

when building in two steps, i.e., first with `--skip-native` and then with `--skip-java`.