### PR TITLE
Fix 2 step build process

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -234,8 +234,6 @@ jobs:
   build-and-test-2-step:
     name: 2-step Linux Build and test ${{ matrix.mandrel-ref }} branch/tag
     runs-on: ubuntu-latest
-    # don't fail the workflow till we fix the build issue like we did for 21.2 in #168
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In the 2 step build process we originally decided to keep the
native-image bash launcher and the macros generation for the
native-image libraries as part of the native build step.

This however is no longer functional as shown in #186 so this patch
moves them to the java build step.

Closes: #186