### PR TITLE
Nashorn dependency is not needed after fixes upstream

### DIFF
--- a/build.java
+++ b/build.java
@@ -799,7 +799,6 @@ class Mx
         final Path suitePy = Path.of("substratevm", "mx.substratevm", "suite.py");
         final Path path = mandrelRepo.apply(suitePy);
         final List<String> dependencies = Arrays.asList(
-            "jdk.scripting.nashorn@11..14", // workaround for https://github.com/graalvm/mandrel/issues/280
             "com.oracle.svm.truffle",
             "com.oracle.svm.truffle.api                   to org.graalvm.truffle",
             "com.oracle.truffle.api.TruffleLanguage.Provider",


### PR DESCRIPTION
The upstream fix was:
https://github.com/oracle/graal/pull/3793

The issue was that for a native image build of the native agents (that's issue https://github.com/graalvm/mandrel/issues/280) it uses a module build. Thus, it expects dependencies available on the module path only. This fails for the native image agent build prior the fix of https://github.com/oracle/graal/pull/3793 for JDK 11-14 based builds since there are substitutions being done in the `org.graalvm.nativeimage.builder` module. For the native-image-agent lib nashorn isn't needed, thus the substitution shouldn't get pulled in. That's essentially what https://github.com/oracle/graal/pull/3793/files#diff-fe3ac83514d73f6c0c5f27e3ee0557566c07da807f0803aa6d285a235b5cf6f5R34 does. Therefore, we don't need the mandrel specific dependency anymore.

Tested this with a JDK 17-based and JDK 11-based mandrel build.