### PR TITLE
Add maven pom files for svm configure tool 

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -276,9 +276,26 @@ jobs:
     - name: Build Mandrel JDK
       run: |
         # Build the Java bits
-        ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --skip-native --mandrel-home temp-build
+        ${JAVA_HOME}/bin/java -ea build.java \
+        --verbose \
+        --mx-home ${MX_HOME} \
+        --mandrel-repo ${MANDREL_REPO} \
+        --mandrel-version "${MANDREL_VERSION}" \
+        --skip-native \
+        --maven-install \
+        --maven-deploy \
+        --maven-version "3.6.0" \
+        --maven-repo-id myRepo \
+        --maven-url "file:///tmp/myRepo" \
+        --mandrel-home temp-build
         # Build the native bits
-        ./temp-build/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --skip-java --archive-suffix tar.gz
+        ./temp-build/bin/java -ea build.java \
+        --verbose \
+        --mx-home ${MX_HOME} \
+        --mandrel-repo ${MANDREL_REPO} \
+        --mandrel-version "${MANDREL_VERSION}" \
+        --skip-java \
+        --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
         export ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
         mv ${ARCHIVE_NAME} mandrel-java11-linux-amd64.tar.gz

--- a/resources/assembly/svm-configure/pom.xml
+++ b/resources/assembly/svm-configure/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>36</version>
+    </parent>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>svm-configure</artifactId>
+    <version>999-ASSEMBLY</version>
+
+    <name>SVM Configure</name>
+    <description>SubstrateVM native-image configuration tool</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm-configure</artifactId>
+            <version>999-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>999</Implementation-Version>
+                            <Java-Build>${java.vm.version}</Java-Build>
+                        </manifestEntries>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/resources/release/svm-configure/pom.xml
+++ b/resources/release/svm-configure/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>svm-configure</artifactId>
+    <version>999</version>
+
+    <name>SVM Configure</name>
+    <description>SubstrateVM native-image configuration tool</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+</project>


### PR DESCRIPTION
https://github.com/graalvm/mandrel-packaging/pull/154/commits/210dcd77871a088f86e87df5e16278b6dc840313 included the new dependency svm-configure in the build but did not provide pom files for `--maven-install` and `--maven-deploy`