### PR TITLE
Add maven pom files for svm configure tool and native image base

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -276,9 +276,26 @@ jobs:
     - name: Build Mandrel JDK
       run: |
         # Build the Java bits
-        ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --skip-native --mandrel-home temp-build
+        ${JAVA_HOME}/bin/java -ea build.java \
+        --verbose \
+        --mx-home ${MX_HOME} \
+        --mandrel-repo ${MANDREL_REPO} \
+        --mandrel-version "${MANDREL_VERSION}" \
+        --skip-native \
+        --maven-install \
+        --maven-deploy \
+        --maven-version "3.6.0" \
+        --maven-repo-id myRepo \
+        --maven-url "file:///tmp/myRepo" \
+        --mandrel-home temp-build
         # Build the native bits
-        ./temp-build/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --skip-java --archive-suffix tar.gz
+        ./temp-build/bin/java -ea build.java \
+        --verbose \
+        --mx-home ${MX_HOME} \
+        --mandrel-repo ${MANDREL_REPO} \
+        --mandrel-version "${MANDREL_VERSION}" \
+        --skip-java \
+        --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
         export ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
         mv ${ARCHIVE_NAME} mandrel-java11-linux-amd64.tar.gz

--- a/build.java
+++ b/build.java
@@ -1325,7 +1325,6 @@ class PathFinder
             LOG.debugf("Trying path: %s", file);
             if (new File(file).exists())
             {
-                // returning file without suffix
                 return Path.of(file);
             }
         }
@@ -1446,14 +1445,8 @@ class Maven
                 , String.format("-DartifactId=%s", artifact.artifactId)
                 , String.format("-Dversion=%s", Options.snapshotVersion(options))
                 , "-Dpackaging=jar"
-                , String.format(
-                    "-Dfile=%s.jar"
-                    , artifact.distsPath.toString()
-                )
-                , String.format(
-                    "-Dsources=%s.src.zip"
-                    , artifact.distsPath
-                )
+                , String.format("-Dfile=%s", artifact.distsPath)
+                , String.format("-Dsources=%s", artifact.distsPath.toString().replace(".jar", ".src.zip"))
                 , "-DcreateChecksum=true"
             )
             , mandrelRepo
@@ -1530,7 +1523,7 @@ class Maven
         Artifact(String groupId, String artifactId, Path distsPath)
         {
             this.groupId = groupId;
-            this.artifactId = artifactId;
+            this.artifactId = artifactId.replace(".jar", "");
             this.distsPath = distsPath;
         }
     }

--- a/resources/assembly/native-image-base/pom.xml
+++ b/resources/assembly/native-image-base/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>36</version>
+    </parent>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>native-image-base</artifactId>
+    <version>999-ASSEMBLY</version>
+
+    <name>Native Image base</name>
+    <description>Native Image base that can be shared by native image building and pointsto.</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>native-image-base</artifactId>
+            <version>999-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>999</Implementation-Version>
+                            <Java-Build>${java.vm.version}</Java-Build>
+                        </manifestEntries>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/resources/assembly/svm-configure/pom.xml
+++ b/resources/assembly/svm-configure/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>36</version>
+    </parent>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>svm-configure</artifactId>
+    <version>999-ASSEMBLY</version>
+
+    <name>SVM Configure</name>
+    <description>SubstrateVM native-image configuration tool</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm-configure</artifactId>
+            <version>999-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>999</Implementation-Version>
+                            <Java-Build>${java.vm.version}</Java-Build>
+                        </manifestEntries>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/resources/release/native-image-base/pom.xml
+++ b/resources/release/native-image-base/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>native-image-base</artifactId>
+    <version>999</version>
+
+    <name>Native Image base</name>
+    <description>Native Image base that can be shared by native image building and pointsto.</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+</project>

--- a/resources/release/svm-configure/pom.xml
+++ b/resources/release/svm-configure/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.nativeimage</groupId>
+    <artifactId>svm-configure</artifactId>
+    <version>999</version>
+
+    <name>SVM Configure</name>
+    <description>SubstrateVM native-image configuration tool</description>
+    <url>https://github.com/graalvm/mandrel</url>
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/graalvm/mandrel.git</connection>
+        <developerConnection>scm:git:git@github.com:graalvm/mandrel.git</developerConnection>
+        <url>https://github.com/graalvm/mandrel</url>
+    </scm>
+</project>


### PR DESCRIPTION
+ Applies https://github.com/graalvm/mandrel-packaging/pull/214 against `master`

  4cc318e778b651a330d9512a6f720afa2de4e34d included the new dependency svm-configure in the build but did not provide pom files for `--maven-install` and `--maven-deploy`

+ Fixes issue with 063842848f3fd6f57ad09423b6f6f364d9ddd8a6 that included the new dependency native-image-base in the build but did not provide pom files for `--maven-install` and `--maven-deploy`
+ Fixes issue with `--maven-install` and `--maven-deploy` caused by cd440c05622ae44064f3f0716a3d6ca3f9c29d29 
+ Adds testing for `--maven-install` and `--maven-deploy`