### PR TITLE
Move native-image launcher patching to 2nd step in 2 step builds

### DIFF
--- a/build.java
+++ b/build.java
@@ -104,9 +104,6 @@ public class build
             FileSystem.copy(mandrelRepo.resolve(
                     Path.of("sdk", "mxbuild", PLATFORM, IS_WINDOWS ? "native-image.exe.image-bash" : "native-image.image-bash",
                             IS_WINDOWS ? "native-image.cmd" : "native-image")), nativeImage);
-
-            logger.debugf("Patch native image...");
-            patchNativeImageLauncher(nativeImage, options.mandrelVersion);
         }
 
         if (!options.skipNative)
@@ -163,6 +160,9 @@ public class build
                 Files.createSymbolicLink(mandrelHome.resolve(
                     Path.of("bin", "native-image")), Path.of("..", "lib", "svm", "bin", "native-image"));
             }
+
+            logger.debugf("Patch native image...");
+            patchNativeImageLauncher(nativeImage, options.mandrelVersion);
 
             if (!options.skipNativeAgents)
             {


### PR DESCRIPTION
This allows us to set the version as late as possible.