### PR TITLE
Release publishing update, Downloads artifatcs, Format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 target
 .env
+artifacts

--- a/release-scripts/mandrel-release.java
+++ b/release-scripts/mandrel-release.java
@@ -15,7 +15,16 @@ import org.eclipse.jgit.console.ConsoleCredentialsProvider;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
-import org.kohsuke.github.*;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHMilestone;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRelease;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHTag;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.PagedIterable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -26,7 +35,12 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -35,8 +49,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Command(name = "mandrel-release", mixinStandardHelpOptions = true,
-        description = "Scipt automating part of the Mandrel release process")
-class MandrelRelease implements Callable<Integer> {
+    description = "Scipt automating part of the Mandrel release process")
+class MandrelRelease implements Callable<Integer>
+{
 
     public static final String GITFORGE_URL = "git@github.com:";
     public static final String REPOSITORY_NAME = "graalvm/mandrel";
@@ -66,18 +81,22 @@ class MandrelRelease implements Callable<Integer> {
     private MandrelVersion newVersion = null;
     private String developBranch = null;
 
-    public static void main(String... args) {
+    public static void main(String... args)
+    {
         int exitCode = new CommandLine(new MandrelRelease()).execute(args);
         System.exit(exitCode);
     }
 
     @Override
-    public Integer call() {
-        if (!suffix.equals("Final") && !Pattern.compile("^(Alpha|Beta)\\d*$").matcher(suffix).find()) {
+    public Integer call()
+    {
+        if (!suffix.equals("Final") && !Pattern.compile("^(Alpha|Beta)\\d*$").matcher(suffix).find())
+        {
             error("Invalid version suffix : " + suffix);
         }
 
-        if (!Path.of(mandrelRepo).toFile().exists()) {
+        if (!Path.of(mandrelRepo).toFile().exists())
+        {
             error("Path " + mandrelRepo + " does not exist");
         }
 
@@ -85,7 +104,8 @@ class MandrelRelease implements Callable<Integer> {
         info("Current version is " + version);
         version.suffix = suffix; // TODO: if Alpha/Beta autobump suffix number?
 
-        if (suffix.equals("Final")) {
+        if (suffix.equals("Final"))
+        {
             newVersion = version.getNewVersion();
             info("New version will be " + newVersion.majorMinorMicroPico());
             developBranch = "develop/mandrel-" + newVersion;
@@ -93,20 +113,26 @@ class MandrelRelease implements Callable<Integer> {
         releaseBranch = "release/mandrel-" + version;
         baseBranch = "mandrel/" + version.majorMinor();
 
-        if (!phase.equals("prepare") && !phase.equals("release")) {
+        if (!phase.equals("prepare") && !phase.equals("release"))
+        {
             throw new IllegalArgumentException(phase + " is not a valid phase. Please use \"prepare\" or \"release\".");
         }
 
-        if (phase.equals("release")) {
+        if (phase.equals("release"))
+        {
             createGHRelease();
         }
-        if (!suffix.equals("Final")) {
+        if (!suffix.equals("Final"))
+        {
             return 0;
         }
         checkAndPrepareRepository();
-        if (phase.equals("release")) {
+        if (phase.equals("release"))
+        {
             updateSuites(this::updateReleaseAndBumpVersionInSuite);
-        } else {
+        }
+        else
+        {
             updateSuites(this::markSuiteAsRelease);
         }
         final String authorEmail = commitAndPushChanges();
@@ -114,55 +140,72 @@ class MandrelRelease implements Callable<Integer> {
         return 0;
     }
 
-    private void checkAndPrepareRepository() {
-        try (Git git = Git.open(new File(mandrelRepo))) {
-            if (!git.getRepository().getBranch().equals(baseBranch)) {
+    private void checkAndPrepareRepository()
+    {
+        try (Git git = Git.open(new File(mandrelRepo)))
+        {
+            if (!git.getRepository().getBranch().equals(baseBranch))
+            {
                 error("Please checkout " + baseBranch + " and try again!");
             }
             final Status status = git.status().call();
-            if (status.hasUncommittedChanges() || !status.getChanged().isEmpty()) {
+            if (status.hasUncommittedChanges() || !status.getChanged().isEmpty())
+            {
                 error("Status of branch " + baseBranch + " is not clean, aborting!");
             }
 
             maybeCreateRemote(git);
             final String newBranch = phase.equals("release") ? developBranch : releaseBranch;
-            try {
+            try
+            {
                 git.checkout().setCreateBranch(true).setName(newBranch).setStartPoint(baseBranch).call();
                 info("Created new branch " + newBranch + " based on " + baseBranch);
-            } catch (RefAlreadyExistsException e) {
+            }
+            catch (RefAlreadyExistsException e)
+            {
                 warn(e.getMessage());
                 gitCheckout(git, newBranch);
                 git.reset().setRef(baseBranch).setMode(ResetCommand.ResetType.HARD).call();
                 warn(newBranch + " reset (hard) to " + baseBranch);
             }
-        } catch (IOException | GitAPIException | URISyntaxException e) {
+        }
+        catch (IOException | GitAPIException | URISyntaxException e)
+        {
             e.printStackTrace();
             error(e.getMessage());
         }
     }
 
-    private void maybeCreateRemote(Git git) throws URISyntaxException, GitAPIException {
+    private void maybeCreateRemote(Git git) throws URISyntaxException, GitAPIException
+    {
         final String forkURL = GITFORGE_URL + forkName;
         final URIish forkURI = new URIish(forkURL);
         RemoteConfig remote = getRemoteConfig(git);
-        if (remote != null && !remote.getURIs().stream().anyMatch(u -> forkURI.equals(u))) {
+        if (remote != null && !remote.getURIs().stream().anyMatch(u -> forkURI.equals(u)))
+        {
             error("Remote " + REMOTE_NAME + " already exists and does not point to " + forkURL +
-                    "\nPlease remove with `git remote remove " + REMOTE_NAME + "` and try again.");
+                "\nPlease remove with `git remote remove " + REMOTE_NAME + "` and try again.");
         }
         git.remoteAdd().setName(REMOTE_NAME).setUri(forkURI).call();
         remote = getRemoteConfig(git);
-        if (remote != null && remote.getURIs().stream().anyMatch(u -> forkURI.equals(u))) {
+        if (remote != null && remote.getURIs().stream().anyMatch(u -> forkURI.equals(u)))
+        {
             info("Git remote " + REMOTE_NAME + " points to " + forkURL);
-        } else {
+        }
+        else
+        {
             error("Failed to add remote " + REMOTE_NAME + " pointing to " + forkURL);
         }
     }
 
-    private RemoteConfig getRemoteConfig(Git git) throws GitAPIException {
+    private RemoteConfig getRemoteConfig(Git git) throws GitAPIException
+    {
         final List<RemoteConfig> remotes = git.remoteList().call();
         RemoteConfig remote = null;
-        for (int i = 0; i < remotes.size(); i++) {
-            if (remotes.get(i).getName().equals(REMOTE_NAME)) {
+        for (int i = 0; i < remotes.size(); i++)
+        {
+            if (remotes.get(i).getName().equals(REMOTE_NAME))
+            {
                 remote = remotes.get(i);
                 break;
             }
@@ -172,108 +215,135 @@ class MandrelRelease implements Callable<Integer> {
 
     /**
      * Visit all suite.py files and change the "release" and "version" fields
-     *
      */
-    private void updateSuites(Consumer<File> updater) {
+    private void updateSuites(Consumer<File> updater)
+    {
         File cwd = new File(mandrelRepo);
         Stream.of(Objects.requireNonNull(cwd.listFiles()))
-                .filter(File::isDirectory)
-                .flatMap(path -> Stream.of(Objects.requireNonNull(path.listFiles())).filter(child -> child.getName().startsWith("mx.")))
-                .map(path -> new File(path, "suite.py"))
-                .filter(File::exists)
-                .forEach(updater);
+            .filter(File::isDirectory)
+            .flatMap(path -> Stream.of(Objects.requireNonNull(path.listFiles())).filter(child -> child.getName().startsWith("mx.")))
+            .map(path -> new File(path, "suite.py"))
+            .filter(File::exists)
+            .forEach(updater);
         info("Updated suites");
     }
 
     /**
      * Visit {@code suite} file and change the "release" value to {@code asRelease}
-     *  @param suite
      *
+     * @param suite
      */
-    private void markSuiteAsRelease(File suite) {
-        try {
+    private void markSuiteAsRelease(File suite)
+    {
+        try
+        {
             info("Marking " + suite.getPath());
             List<String> lines = Files.readAllLines(suite.toPath());
             final String pattern = "(.*\"release\" : )False(.*)";
             final Pattern releasePattern = Pattern.compile(pattern);
-            for (int i = 0; i < lines.size(); i++) {
+            for (int i = 0; i < lines.size(); i++)
+            {
                 final Matcher releaseMatcher = releasePattern.matcher(lines.get(i));
-                if (releaseMatcher.find()) {
+                if (releaseMatcher.find())
+                {
                     String newLine = releaseMatcher.group(1) + "True" + releaseMatcher.group(2);
                     lines.set(i, newLine);
                     break;
                 }
             }
             Files.write(suite.toPath(), lines, StandardCharsets.UTF_8);
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             e.printStackTrace();
             error(e.getMessage());
         }
     }
 
-    private void updateReleaseAndBumpVersionInSuite(File suite) {
-        try {
+    private void updateReleaseAndBumpVersionInSuite(File suite)
+    {
+        try
+        {
             info("Updating " + suite.getPath());
             List<String> lines = Files.readAllLines(suite.toPath());
             final Pattern releasePattern = Pattern.compile("(.*\"release\" : )True(.*)");
             final Pattern versionPattern = Pattern.compile("(.*\"version\" : \")" + version.majorMinorMicroPico() + "(\".*)");
-            for (int i = 0; i < lines.size(); i++) {
+            for (int i = 0; i < lines.size(); i++)
+            {
                 final Matcher releaseMatcher = releasePattern.matcher(lines.get(i));
-                if (releaseMatcher.find()) {
+                if (releaseMatcher.find())
+                {
                     String newLine = releaseMatcher.group(1) + "False" + releaseMatcher.group(2);
                     lines.set(i, newLine);
                 }
                 final Matcher versionMatcher = versionPattern.matcher(lines.get(i));
-                if (versionMatcher.find()) {
+                if (versionMatcher.find())
+                {
                     String newLine = versionMatcher.group(1) + newVersion.majorMinorMicroPico() + versionMatcher.group(2);
                     lines.set(i, newLine);
                 }
             }
             Files.write(suite.toPath(), lines, StandardCharsets.UTF_8);
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             e.printStackTrace();
             error(e.getMessage());
         }
     }
 
-    private String commitAndPushChanges() {
-        try (Git git = Git.open(new File(mandrelRepo))) {
+    private String commitAndPushChanges()
+    {
+        try (Git git = Git.open(new File(mandrelRepo)))
+        {
             ConsoleCredentialsProvider.install(); // Needed for gpg signing
             final String message;
-            if (phase.equals("release")) {
+            if (phase.equals("release"))
+            {
                 message = "Unmark suites and bump version to " + newVersion.majorMinorMicroPico() + " [skip ci]";
-            } else {
+            }
+            else
+            {
                 message = "Mark suites for " + version + " release [skip ci]";
             }
             final RevCommit commit = git.commit().setAll(true).setMessage(message).setSign(signCommits).call();
             final String author = commit.getAuthorIdent().getEmailAddress();
             info("Changes commited");
             git.push().setForce(true).setRemote(REMOTE_NAME).setDryRun(dryRun).call();
-            if (dryRun) {
+            if (dryRun)
+            {
                 warn("Changes not pushed to remote due to --dry-run being present");
-            } else {
+            }
+            else
+            {
                 info("Changes pushed to remote " + REMOTE_NAME);
             }
             gitCheckout(git, baseBranch);
             return author;
-        } catch (IOException | GitAPIException e) {
+        }
+        catch (IOException | GitAPIException e)
+        {
             e.printStackTrace();
             error(e.getMessage());
         }
         return null;
     }
 
-    private void gitCheckout(Git git, String baseBranch) throws GitAPIException {
+    private void gitCheckout(Git git, String baseBranch) throws GitAPIException
+    {
         git.checkout().setName(baseBranch).call();
         info("Checked out " + baseBranch);
     }
 
-    private void openPR(String authorEmail) {
+    private void openPR(String authorEmail)
+    {
         assert suffix.equals("Final");
         GitHub github = connectToGitHub();
-        try {
+        try
+        {
             final GHRepository repository = github.getRepository(REPOSITORY_NAME);
-            if (dryRun) {
+            if (dryRun)
+            {
                 warn("Pull request creation skipped due to --dry-run being present");
                 return;
             }
@@ -281,26 +351,30 @@ class MandrelRelease implements Callable<Integer> {
             final String title;
             final String body;
             String head = "";
-            if (!forkName.equals(REPOSITORY_NAME)) {
+            if (!forkName.equals(REPOSITORY_NAME))
+            {
                 head = forkName.split("/")[0] + ":";
             }
-            if (phase.equals("release")) {
+            if (phase.equals("release"))
+            {
                 title = "Unmark suites and bump version to " + newVersion.majorMinorMicroPico();
                 head += developBranch;
                 body = "This PR was automatically generated by `mandrel-release.java` of graalvm/mandrel-packaging!";
-            } else {
+            }
+            else
+            {
                 title = "Mark suites for " + version + " release";
                 head += releaseBranch;
                 body = "This PR was automatically generated by `mandrel-release.java` of graalvm/mandrel-packaging!\n\n" +
-                        "Please tag branch `" + baseBranch + "` after merging, and push the tag.\n" +
-                        "```\n" +
-                        "git checkout " + baseBranch + "\n" +
-                        "git pull upstream " + baseBranch + "\n" +
-                        "git tag -a mandrel-" + version + " -m \"mandrel-" + version + "\" -s\n" +
-                        "git push upstream mandrel-" + version + "\n" +
-                        "```\n" +
-                        "where `upstream` is the git remote showing to https://github.com/graalvm/mandrel\n\n" +
-                        "Make sure to create the same tag in the mandrel-packaging repository!";
+                    "Please tag branch `" + baseBranch + "` after merging, and push the tag.\n" +
+                    "```\n" +
+                    "git checkout " + baseBranch + "\n" +
+                    "git pull upstream " + baseBranch + "\n" +
+                    "git tag -a mandrel-" + version + " -m \"mandrel-" + version + "\" -s\n" +
+                    "git push upstream mandrel-" + version + "\n" +
+                    "```\n" +
+                    "where `upstream` is the git remote showing to https://github.com/graalvm/mandrel\n\n" +
+                    "Make sure to create the same tag in the mandrel-packaging repository!";
             }
 
             final GHPullRequest pullRequest = repository.createPullRequest(title, head, baseBranch, body, true, false);
@@ -311,30 +385,44 @@ class MandrelRelease implements Callable<Integer> {
             final GHUser zakkak = github.getUser("zakkak");
 
             ArrayList<GHUser> reviewers = new ArrayList<>();
-            if (!authorEmail.contains("galder")) {
+            if (!authorEmail.contains("galder"))
+            {
                 reviewers.add(galderz);
-            } else {
+            }
+            else
+            {
                 pullRequest.addAssignees(Collections.singletonList(galderz));
             }
-            if (!authorEmail.contains("sgehwolf") && !authorEmail.contains("jerboaa")) {
+            if (!authorEmail.contains("sgehwolf") && !authorEmail.contains("jerboaa"))
+            {
                 reviewers.add(jerboaa);
-            } else {
+            }
+            else
+            {
                 pullRequest.addAssignees(Collections.singletonList(jerboaa));
             }
-            if (!authorEmail.contains("karm")) {
+            if (!authorEmail.contains("karm"))
+            {
                 reviewers.add(karm);
-            } else {
+            }
+            else
+            {
                 pullRequest.addAssignees(Collections.singletonList(karm));
             }
-            if (!authorEmail.contains("zakkak")) {
+            if (!authorEmail.contains("zakkak"))
+            {
                 reviewers.add(zakkak);
-            } else {
+            }
+            else
+            {
                 pullRequest.addAssignees(Collections.singletonList(zakkak));
             }
             pullRequest.requestReviewers(reviewers);
 
             info("Pull request " + pullRequest.getHtmlUrl() + " created");
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             e.printStackTrace();
             error(e.getMessage());
         }
@@ -345,35 +433,44 @@ class MandrelRelease implements Callable<Integer> {
      *
      * @return
      */
-    private MandrelVersion getCurrentVersion() {
+    private MandrelVersion getCurrentVersion()
+    {
         final Path substrateSuite = Path.of(mandrelRepo, "substratevm", "mx.substratevm", "suite.py");
-        try {
+        try
+        {
             final List<String> lines = Files.readAllLines(substrateSuite);
             final Pattern versionPattern = Pattern.compile("\"version\" : \"([\\d.]+)\"");
-            for (String line : lines) {
+            for (String line : lines)
+            {
                 final Matcher versionMatcher = versionPattern.matcher(line);
-                if (versionMatcher.find()) {
+                if (versionMatcher.find())
+                {
                     final String version = versionMatcher.group(1);
                     return new MandrelVersion(version);
                 }
             }
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             e.printStackTrace();
             error(e.getMessage());
         }
         return null;
     }
 
-    private void createGHRelease() {
+    private void createGHRelease()
+    {
         GitHub github = connectToGitHub();
-        try {
+        try
+        {
             final GHRepository repository = github.getRepository(REPOSITORY_NAME);
             final PagedIterable<GHMilestone> ghMilestones = repository.listMilestones(GHIssueState.OPEN);
             final String finalVersion = version.majorMinorMicroPico() + "-Final";
             final GHMilestone milestone = ghMilestones.toList().stream().filter(m -> m.getTitle().equals(finalVersion)).findAny().orElse(null);
             final List<GHTag> tags = repository.listTags().toList();
             String changelog = createChangelog(repository, milestone, tags);
-            if (dryRun) {
+            if (dryRun)
+            {
                 warn("Skipping release due to --dry-run");
                 info("Release body would look like");
                 System.out.println(releaseMainBody(version, changelog));
@@ -381,227 +478,270 @@ class MandrelRelease implements Callable<Integer> {
             }
             // Ensure that the tag exists
             final String tag = "mandrel-" + version;
-            if (tags.stream().noneMatch(x -> x.getName().equals(tag))) {
+            if (tags.stream().noneMatch(x -> x.getName().equals(tag)))
+            {
                 error("Please create tag " + tag + " and try again");
             }
             final GHRelease ghRelease = repository.createRelease(tag)
-                    .name("Mandrel " + version)
-                    .prerelease(!suffix.equals("Final"))
-                    .body(releaseMainBody(version, changelog))
-                    .draft(true)
-                    .create();
+                .name("Mandrel " + version)
+                .prerelease(!suffix.equals("Final"))
+                .body(releaseMainBody(version, changelog))
+                .draft(true)
+                .create();
             uploadAssets(version.toString(), ghRelease);
             info("Created new draft release: " + ghRelease.getHtmlUrl());
             info("Please review and publish!");
             manageMilestones(repository, ghMilestones, milestone);
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             e.printStackTrace();
             error(e.getMessage());
         }
     }
 
-    private void uploadAssets(String fullVersion, GHRelease ghRelease) throws IOException {
+    private void uploadAssets(String fullVersion, GHRelease ghRelease) throws IOException
+    {
         final File[] assets = {
-                new File("mandrel-java11-linux-amd64-" + fullVersion + ".tar.gz"),
-                new File("mandrel-java11-linux-amd64-" + fullVersion + ".tar.gz.sha1"),
-                new File("mandrel-java11-linux-amd64-" + fullVersion + ".tar.gz.sha256"),
-                new File("mandrel-java11-windows-amd64-" + fullVersion + ".zip"),
-                new File("mandrel-java11-windows-amd64-" + fullVersion + ".zip.sha1"),
-                new File("mandrel-java11-windows-amd64-" + fullVersion + ".zip.sha256")};
+            new File("mandrel-java11-linux-amd64-" + fullVersion + ".tar.gz"),
+            new File("mandrel-java11-linux-amd64-" + fullVersion + ".tar.gz.sha1"),
+            new File("mandrel-java11-linux-amd64-" + fullVersion + ".tar.gz.sha256"),
+            new File("mandrel-java11-windows-amd64-" + fullVersion + ".zip"),
+            new File("mandrel-java11-windows-amd64-" + fullVersion + ".zip.sha1"),
+            new File("mandrel-java11-windows-amd64-" + fullVersion + ".zip.sha256")};
 
-        for (File f : assets) {
-            if (!f.exists()) {
+        for (File f : assets)
+        {
+            if (!f.exists())
+            {
                 warn("Archive \"" + f.getName() + "\" was not found. Skipping asset upload.");
                 warn("Please upload assets manually.");
                 return;
             }
         }
 
-        for (File f : assets) {
+        for (File f : assets)
+        {
             info("Uploading " + f.getName());
-            if (f.getName().endsWith("tar.gz")) {
+            if (f.getName().endsWith("tar.gz"))
+            {
                 ghRelease.uploadAsset(f, "application/gzip");
-            } else if (f.getName().endsWith("zip")) {
+            }
+            else if (f.getName().endsWith("zip"))
+            {
                 ghRelease.uploadAsset(f, "application/zip");
-            } else {
+            }
+            else
+            {
                 ghRelease.uploadAsset(f, "text/plain");
             }
             info("Uploaded " + f.getName());
         }
     }
 
-    private String releaseMainBody(MandrelVersion version, String changelog) {
+    private String releaseMainBody(MandrelVersion version, String changelog)
+    {
         return "# Mandrel\n" +
-                "\n" +
-                "Mandrel " + version + " is a downstream distribution of the [GraalVM community edition " + version.majorMinorMicro() + "](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-" + version.majorMinorMicro() + ").\n" +
-                "Mandrel's main goal is to provide a `native-image` release specifically to support [Quarkus](https://quarkus.io).\n" +
-                "The aim is to align the `native-image` capabilities from GraalVM with OpenJDK and Red Hat Enterprise Linux libraries to improve maintainability for native Quarkus applications.\n" +
-                "\n" +
-                "## How Does Mandrel Differ From Graal\n" +
-                "\n" +
-                "Mandrel releases are built from a code base derived from the upstream GraalVM code base, with only minor changes but some significant exclusions.\n" +
-                "They support the same native image capability as GraalVM with no significant changes to functionality.\n" +
-                "They do not include support for Polyglot programming via the Truffle interpreter and compiler framework.\n" +
-                "In consequence, it is not possible to extend Mandrel by downloading languages from the Truffle language catalogue.\n" +
-                "\n" +
-                "Mandrel is also built slightly differently to GraalVM, using the standard OpenJDK project release of jdk11u.\n" +
-                "This means it does not profit from a few small enhancements that Oracle have added to the version of OpenJDK used to build their own GraalVM downloads.\n" +
-                "Most of these enhancements are to the JVMCI module that allows the Graal compiler to be run inside OpenJDK.\n" +
-                "The others are small cosmetic changes to behaviour.\n" +
-                "These enhancements may in some cases cause minor differences in the progress of native image generation.\n" +
-                "They should not cause the resulting images themselves to execute in a noticeably different manner.\n" +
-                "\n" +
-                "### Prerequisites\n" +
-                "\n" +
-                "Mandrel's `native-image` depends on the following packages:\n" +
-                "* freetype-devel\n" +
-                "* gcc\n" +
-                "* glibc-devel\n" +
-                "* libstdc++-static\n" +
-                "* zlib-devel\n" +
-                "\n" +
-                "On Fedora/CentOS/RHEL they can be installed with:\n" +
-                "```bash\n" +
-                "dnf install glibc-devel zlib-devel gcc freetype-devel libstdc++-static\n" +
-                "```\n" +
-                "\n" +
-                "**Note**: The package might be called `glibc-static` or `libstdc++-devel` instead of `libstdc++-static` depending on your system.\n" +
-                "If the system is missing stdc++, `gcc-c++` package is needed too.\n" +
-                "\n" +
-                "On Ubuntu-like systems with:\n" +
-                "```bash\n" +
-                "apt install g++ zlib1g-dev libfreetype6-dev\n" +
-                "```\n" +
-                "\n" +
-                "## Quick start\n" +
-                "\n" +
-                "```\n" +
-                "$ tar -xf mandrel-java11-linux-amd64-" + version + ".tar.gz\n" +
-                "$ export JAVA_HOME=\"$( pwd )/mandrel-java11-" + version + "\"\n" +
-                "$ export GRAALVM_HOME=\"${JAVA_HOME}\"\n" +
-                "$ export PATH=\"${JAVA_HOME}/bin:${PATH}\"\n" +
-                "$ curl -O -J https://code.quarkus.io/d?e=io.quarkus:quarkus-resteasy\n" +
-                "$ unzip code-with-quarkus.zip\n" +
-                "$ cd code-with-quarkus/\n" +
-                "$ ./mvnw package -Pnative\n" +
-                "$ ./target/code-with-quarkus-1.0.0-SNAPSHOT-runner\n" +
-                "```\n" +
-                "\n" +
-                "### Quarkus builder image\n" +
-                "\n" +
-                "The Quarkus builder image for this release is still being prepared, please try again later.\n" +
-                "<!--\n" +
-                "Mandrel Quarkus builder image can be used to build a Quarkus native Linux executable right away without any GRAALVM_HOME setup.\n" +
-                "\n" +
-                "```bash\n" +
-                "curl -O -J  https://code.quarkus.io/d?e=io.quarkus:quarkus-resteasy\n" +
-                "unzip code-with-quarkus.zip\n" +
-                "cd code-with-quarkus\n" +
-                "        ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:" + version + "-java11\n" +
-                "        ./target/code-with-quarkus-1.0.0-SNAPSHOT-runner\n" +
-                "```\n" +
-                "\n" +
-                "One can use the builder image on Windows with Docker Desktop (mind `Resources-> File sharing` settings so as Quarkus project directory is mountable).\n" +
-                "\n" +
-                "```batchfile\n" +
-                "powershell -c \"Invoke-WebRequest -OutFile quarkus.zip -Uri https://code.quarkus.io/d?e=io.quarkus:quarkus-resteasy\"\n" +
-                "powershell -c \"Expand-Archive -Path quarkus.zip -DestinationPath . -Force\n" +
-                "cd code-with-quarkus\n" +
-                "mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:" + version + "-java11\n" +
-                "docker build -f src/main/docker/Dockerfile.native -t my-quarkus-mandrel-app .\n" +
-                "        docker run -i --rm -p 8080:8080 my-quarkus-mandrel-app\n" +
-                "```\n" +
-                "-->\n" +
-                changelog +
-                "\n---\n" +
-                "Mandrel " + version + "\n" +
-                "OpenJDK used: " + System.getProperty("java.runtime.version") + "\n";
+            "\n" +
+            "Mandrel " + version + " is a downstream distribution of the [GraalVM community edition " + version.majorMinorMicro() + "](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-" + version.majorMinorMicro() + ").\n" +
+            "Mandrel's main goal is to provide a `native-image` release specifically to support [Quarkus](https://quarkus.io).\n" +
+            "The aim is to align the `native-image` capabilities from GraalVM with OpenJDK and Red Hat Enterprise Linux libraries to improve maintainability for native Quarkus applications.\n" +
+            "\n" +
+            "## How Does Mandrel Differ From Graal\n" +
+            "\n" +
+            "Mandrel releases are built from a code base derived from the upstream GraalVM code base, with only minor changes but some significant exclusions.\n" +
+            "They support the same native image capability as GraalVM with no significant changes to functionality.\n" +
+            "They do not include support for Polyglot programming via the Truffle interpreter and compiler framework.\n" +
+            "In consequence, it is not possible to extend Mandrel by downloading languages from the Truffle language catalogue.\n" +
+            "\n" +
+            "Mandrel is also built slightly differently to GraalVM, using the standard OpenJDK project release of jdk11u.\n" +
+            "This means it does not profit from a few small enhancements that Oracle have added to the version of OpenJDK used to build their own GraalVM downloads.\n" +
+            "Most of these enhancements are to the JVMCI module that allows the Graal compiler to be run inside OpenJDK.\n" +
+            "The others are small cosmetic changes to behaviour.\n" +
+            "These enhancements may in some cases cause minor differences in the progress of native image generation.\n" +
+            "They should not cause the resulting images themselves to execute in a noticeably different manner.\n" +
+            "\n" +
+            "### Prerequisites\n" +
+            "\n" +
+            "Mandrel's `native-image` depends on the following packages:\n" +
+            "* freetype-devel\n" +
+            "* gcc\n" +
+            "* glibc-devel\n" +
+            "* libstdc++-static\n" +
+            "* zlib-devel\n" +
+            "\n" +
+            "On Fedora/CentOS/RHEL they can be installed with:\n" +
+            "```bash\n" +
+            "dnf install glibc-devel zlib-devel gcc freetype-devel libstdc++-static\n" +
+            "```\n" +
+            "\n" +
+            "**Note**: The package might be called `glibc-static` or `libstdc++-devel` instead of `libstdc++-static` depending on your system.\n" +
+            "If the system is missing stdc++, `gcc-c++` package is needed too.\n" +
+            "\n" +
+            "On Ubuntu-like systems with:\n" +
+            "```bash\n" +
+            "apt install g++ zlib1g-dev libfreetype6-dev\n" +
+            "```\n" +
+            "\n" +
+            "## Quick start\n" +
+            "\n" +
+            "```\n" +
+            "$ tar -xf mandrel-java11-linux-amd64-" + version + ".tar.gz\n" +
+            "$ export JAVA_HOME=\"$( pwd )/mandrel-java11-" + version + "\"\n" +
+            "$ export GRAALVM_HOME=\"${JAVA_HOME}\"\n" +
+            "$ export PATH=\"${JAVA_HOME}/bin:${PATH}\"\n" +
+            "$ curl -O -J https://code.quarkus.io/d?e=io.quarkus:quarkus-resteasy\n" +
+            "$ unzip code-with-quarkus.zip\n" +
+            "$ cd code-with-quarkus/\n" +
+            "$ ./mvnw package -Pnative\n" +
+            "$ ./target/code-with-quarkus-1.0.0-SNAPSHOT-runner\n" +
+            "```\n" +
+            "\n" +
+            "### Quarkus builder image\n" +
+            "\n" +
+            "The Quarkus builder image for this release is still being prepared, please try again later.\n" +
+            "<!--\n" +
+            "Mandrel Quarkus builder image can be used to build a Quarkus native Linux executable right away without any GRAALVM_HOME setup.\n" +
+            "\n" +
+            "```bash\n" +
+            "curl -O -J  https://code.quarkus.io/d?e=io.quarkus:quarkus-resteasy\n" +
+            "unzip code-with-quarkus.zip\n" +
+            "cd code-with-quarkus\n" +
+            "        ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:" + version + "-java11\n" +
+            "        ./target/code-with-quarkus-1.0.0-SNAPSHOT-runner\n" +
+            "```\n" +
+            "\n" +
+            "One can use the builder image on Windows with Docker Desktop (mind `Resources-> File sharing` settings so as Quarkus project directory is mountable).\n" +
+            "\n" +
+            "```batchfile\n" +
+            "powershell -c \"Invoke-WebRequest -OutFile quarkus.zip -Uri https://code.quarkus.io/d?e=io.quarkus:quarkus-resteasy\"\n" +
+            "powershell -c \"Expand-Archive -Path quarkus.zip -DestinationPath . -Force\n" +
+            "cd code-with-quarkus\n" +
+            "mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:" + version + "-java11\n" +
+            "docker build -f src/main/docker/Dockerfile.native -t my-quarkus-mandrel-app .\n" +
+            "        docker run -i --rm -p 8080:8080 my-quarkus-mandrel-app\n" +
+            "```\n" +
+            "-->\n" +
+            changelog +
+            "\n---\n" +
+            "Mandrel " + version + "\n" +
+            "OpenJDK used: " + System.getProperty("java.runtime.version") + "\n";
     }
 
-    private String createChangelog(GHRepository repository, GHMilestone milestone, List<GHTag> tags) throws IOException {
-        if (milestone == null) {
+    private String createChangelog(GHRepository repository, GHMilestone milestone, List<GHTag> tags) throws IOException
+    {
+        if (milestone == null)
+        {
             error("No milestone titled " + version.majorMinorMicroPico() + "-Final! Can't produce changelog without it!");
         }
-        if (suffix.equals("Final") && milestone.getOpenIssues() != 0) {
+        if (suffix.equals("Final") && milestone.getOpenIssues() != 0)
+        {
             error("There are still open issues in milestone " + milestone.getTitle() + ". Please take care of them and try again.");
         }
         info("Getting merged PRs for " + milestone.getTitle() + " (" + milestone.getNumber() + ")");
         final Stream<GHPullRequest> mergedPRsInMilestone = repository.getPullRequests(GHIssueState.CLOSED).stream()
-                .filter(pr -> includeInChangelog(pr, milestone));
+            .filter(pr -> includeInChangelog(pr, milestone));
         final Map<Integer, List<GHPullRequest>> collect = mergedPRsInMilestone.collect(Collectors.groupingBy(this::getGroup));
         StringBuilder changelogBuilder = new StringBuilder("\n### Changelog\n\n");
         final String latestReleasedTag = version.getLatestReleasedTag(tags);
         final List<GHPullRequest> noteworthyPRs = collect.get(0);
-        if (noteworthyPRs != null && noteworthyPRs.size() != 0) {
+        if (noteworthyPRs != null && noteworthyPRs.size() != 0)
+        {
             noteworthyPRs.forEach(pr ->
-                    changelogBuilder.append(" * #").append(pr.getNumber()).append(" - ").append(pr.getTitle()).append("\n"));
+                changelogBuilder.append(" * #").append(pr.getNumber()).append(" - ").append(pr.getTitle()).append("\n"));
         }
         final List<GHPullRequest> backportPRs = collect.get(1);
-        if (backportPRs != null && backportPRs.size() != 0) {
+        if (backportPRs != null && backportPRs.size() != 0)
+        {
             changelogBuilder.append("\n#### Backports\n\n");
             backportPRs.forEach(pr ->
-                    changelogBuilder.append(" * #").append(pr.getNumber()).append(" - ").append(pr.getTitle()).append("\n"));
+                changelogBuilder.append(" * #").append(pr.getNumber()).append(" - ").append(pr.getTitle()).append("\n"));
         }
-        if (latestReleasedTag == null) {
+        if (latestReleasedTag == null)
+        {
             changelogBuilder.append("\n<!--\nFor a complete list of changes please visit https://github.com/" + REPOSITORY_NAME + "/compare/")
-                    .append("TODO_REPLACE_WITH_UPSTREAM_TAG").append("...mandrel-").append(version).append("\n-->\n");
-        } else {
+                .append("TODO_REPLACE_WITH_UPSTREAM_TAG").append("...mandrel-").append(version).append("\n-->\n");
+        }
+        else
+        {
             changelogBuilder.append("\nFor a complete list of changes please visit https://github.com/" + REPOSITORY_NAME + "/compare/")
-                    .append(latestReleasedTag).append("...mandrel-").append(version).append("\n");
+                .append(latestReleasedTag).append("...mandrel-").append(version).append("\n");
         }
         return changelogBuilder.toString();
     }
 
-    private void manageMilestones(GHRepository repository, PagedIterable<GHMilestone> ghMilestones, GHMilestone milestone) throws IOException {
-        if (dryRun || !suffix.equals("Final")) {
+    private void manageMilestones(GHRepository repository, PagedIterable<GHMilestone> ghMilestones, GHMilestone milestone) throws IOException
+    {
+        if (dryRun || !suffix.equals("Final"))
+        {
             return;
         }
-        if (milestone != null) {
+        if (milestone != null)
+        {
             milestone.close();
             info("Closed milestone " + milestone.getTitle() + " (" + milestone.getNumber() + ")");
         }
         GHMilestone newMilestone = ghMilestones.toList().stream().filter(m -> m.getTitle().equals(newVersion.toString())).findAny().orElse(null);
-        if (newMilestone == null) {
+        if (newMilestone == null)
+        {
             newMilestone = repository.createMilestone(newVersion.toString(), "");
             info("Created milestone " + newMilestone.getTitle() + " (" + newMilestone.getNumber() + ")");
         }
     }
 
-    private static boolean includeInChangelog(GHPullRequest pr, GHMilestone milestone) {
-        try {
-            if (!pr.isMerged()) {
+    private static boolean includeInChangelog(GHPullRequest pr, GHMilestone milestone)
+    {
+        try
+        {
+            if (!pr.isMerged())
+            {
                 return false;
             }
             return pr.getMilestone() != null && pr.getMilestone().getNumber() == milestone.getNumber();
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             e.printStackTrace();
             return false;
         }
     }
 
-    private Integer getGroup(GHPullRequest pr) {
-        try {
-            if (pr.getLabels().stream().anyMatch(l -> l.getName().equals("release/noteworthy-feature"))) {
+    private Integer getGroup(GHPullRequest pr)
+    {
+        try
+        {
+            if (pr.getLabels().stream().anyMatch(l -> l.getName().equals("release/noteworthy-feature")))
+            {
                 return 0;
             }
-            if (pr.getLabels().stream().anyMatch(l -> l.getName().equals("backport"))) {
+            if (pr.getLabels().stream().anyMatch(l -> l.getName().equals("backport")))
+            {
                 return 1;
             }
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             e.printStackTrace();
             error(e.getMessage());
         }
         return 2;
     }
 
-    private GitHub connectToGitHub() {
+    private GitHub connectToGitHub()
+    {
         GitHub github = null;
-        try {
-             github = GitHubBuilder.fromPropertyFile().build();
-        } catch (IOException e) {
-            try {
+        try
+        {
+            github = GitHubBuilder.fromPropertyFile().build();
+        }
+        catch (IOException e)
+        {
+            try
+            {
                 github = GitHubBuilder.fromEnvironment().build();
-            } catch (IOException ioException) {
+            }
+            catch (IOException ioException)
+            {
                 ioException.printStackTrace();
                 error(ioException.getMessage());
             }
@@ -609,20 +749,24 @@ class MandrelRelease implements Callable<Integer> {
         return github;
     }
 
-    private static void info(String message) {
+    private static void info(String message)
+    {
         System.err.println(Ansi.AUTO.string("[@|bold INFO|@] ") + message);
     }
 
-    private static void warn(String message) {
+    private static void warn(String message)
+    {
         System.err.println(Ansi.AUTO.string("[@|bold,yellow WARN|@] ") + message);
     }
 
-    private static void error(String message) {
+    private static void error(String message)
+    {
         System.err.println(Ansi.AUTO.string("[@|bold,red ERROR|@] ") + message);
         System.exit(1);
     }
 
-    class MandrelVersion implements Comparable<MandrelVersion> {
+    class MandrelVersion implements Comparable<MandrelVersion>
+    {
         final static String MANDREL_VERSION_REGEX = "(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)(-(Final|(Alpha|Beta)\\d*))?";
 
         int major;
@@ -631,7 +775,8 @@ class MandrelRelease implements Callable<Integer> {
         int pico;
         String suffix;
 
-        public MandrelVersion(MandrelVersion mandrelVersion) {
+        public MandrelVersion(MandrelVersion mandrelVersion)
+        {
             this.major = mandrelVersion.major;
             this.minor = mandrelVersion.minor;
             this.micro = mandrelVersion.micro;
@@ -639,11 +784,13 @@ class MandrelRelease implements Callable<Integer> {
             this.suffix = mandrelVersion.suffix;
         }
 
-        public MandrelVersion(String version) {
+        public MandrelVersion(String version)
+        {
             final Pattern versionPattern = Pattern.compile(MandrelVersion.MANDREL_VERSION_REGEX);
             final Matcher versionMatcher = versionPattern.matcher(version);
             boolean found = versionMatcher.find();
-            if (!found) {
+            if (!found)
+            {
                 error("Wrong version format! " + version + " does not match pattern: " + MandrelVersion.MANDREL_VERSION_REGEX);
             }
             major = Integer.parseInt(versionMatcher.group(1));
@@ -658,7 +805,8 @@ class MandrelRelease implements Callable<Integer> {
          *
          * @return The new version
          */
-        private MandrelVersion getNewVersion() {
+        private MandrelVersion getNewVersion()
+        {
             final MandrelVersion mandrelVersion = new MandrelVersion(this);
             mandrelVersion.pico++;
             return mandrelVersion;
@@ -667,28 +815,32 @@ class MandrelRelease implements Callable<Integer> {
         /**
          * Calculates the latest final version by checking major.minor.micro.pico
          *
-         * @return The latest final version
          * @param tags
+         * @return The latest final version
          */
-        private String getLatestReleasedTag(List<GHTag> tags) {
+        private String getLatestReleasedTag(List<GHTag> tags)
+        {
             final String tagPrefix = "mandrel-";
             List<MandrelVersion> finalVersions = tags.stream()
-                    .filter(x -> x.getName().startsWith(tagPrefix + majorMinorMicro()) && x.getName().endsWith("Final"))
-                    .map(x -> new MandrelVersion(x.getName().substring(tagPrefix.length())))
-                    .sorted(Comparator.reverseOrder())
-                    .collect(Collectors.toList());
-            for (MandrelVersion mandrelVersion : finalVersions) {
+                .filter(x -> x.getName().startsWith(tagPrefix + majorMinorMicro()) && x.getName().endsWith("Final"))
+                .map(x -> new MandrelVersion(x.getName().substring(tagPrefix.length())))
+                .sorted(Comparator.reverseOrder())
+                .collect(Collectors.toList());
+            for (MandrelVersion mandrelVersion : finalVersions)
+            {
                 System.out.println(mandrelVersion);
             }
-            assert !finalVersions.isEmpty() : 
+            assert !finalVersions.isEmpty() :
                 "Tag for " + toString() + " is missing, please make sure the tag has been pushed before releasing.";
-            assert compareTo(finalVersions.get(0)) == 0 : 
+            assert compareTo(finalVersions.get(0)) == 0 :
                 "Latest tag (" + finalVersions.get(0) + ") does not match the version of the current branch (" + toString() + "). " +
-                "Please make sure you are on the correct branch and that you have created a tag for the release.";
-            if (finalVersions.size() == 1) {
+                    "Please make sure you are on the correct branch and that you have created a tag for the release.";
+            if (finalVersions.size() == 1)
+            {
                 // There is no Mandrel release before that major.minor.micro, return upstream graal tag instead
                 final String upstreamTag = "vm-" + majorMinorMicro();
-                if (tags.stream().noneMatch(x -> x.getName().equals(upstreamTag))) {
+                if (tags.stream().noneMatch(x -> x.getName().equals(upstreamTag)))
+                {
                     warn("Upstream tag " + upstreamTag + " not found in " + REPOSITORY_NAME + " please add the upstream tag manually in the release text.");
                     return null;
                 }
@@ -697,43 +849,61 @@ class MandrelRelease implements Callable<Integer> {
             return tagPrefix + finalVersions.get(1).toString();
         }
 
-        private String majorMinor() {
+        private String majorMinor()
+        {
             return major + "." + minor;
         }
 
-        private String majorMinorMicro() {
+        private String majorMinorMicro()
+        {
             return major + "." + minor + "." + micro;
         }
 
-        private String majorMinorMicroPico() {
+        private String majorMinorMicroPico()
+        {
             return major + "." + minor + "." + micro + "." + pico;
         }
 
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             String version = majorMinorMicroPico();
-            if (suffix != null) {
+            if (suffix != null)
+            {
                 version += "-" + suffix;
             }
             return version;
         }
 
         @Override
-        public int compareTo(MandrelVersion o) {
+        public int compareTo(MandrelVersion o)
+        {
             assert suffix.equals(o.suffix);
-            if (major > o.major) {
+            if (major > o.major)
+            {
                 return 1;
-            } else if (major == o.major) {
-                if (minor > o.minor) {
+            }
+            else if (major == o.major)
+            {
+                if (minor > o.minor)
+                {
                     return 1;
-                } else if (minor == o.minor) {
-                    if (micro > o.micro) {
+                }
+                else if (minor == o.minor)
+                {
+                    if (micro > o.micro)
+                    {
                         return 1;
-                    } else if (micro == o.micro) {
-                        if (pico > o.pico) {
+                    }
+                    else if (micro == o.micro)
+                    {
+                        if (pico > o.pico)
+                        {
                             return 1;
-                        } else if (pico == o.pico) {
+                        }
+                        else if (pico == o.pico)
+                        {
                             return 0;
                         }
                     }


### PR DESCRIPTION
* Formats code according to what we agreed on in [code-formatting-rules.xml](https://github.com/graalvm/mandrel-packaging/blob/master/code-formatting-rules.xml)
* Adds options to download artifacts from Jenkins before publishing them
* Reads manifests on Jenkins builds to assemble a set of used JDKs

Tested on https://github.com/graalvm/mandrel/releases/tag/mandrel-21.3.1.1-Final

```
$ ./mandrel-release.java release -d --windows-job-build-number=18 --linux-job-build-number=33 -m /home/karm/workspaceRH/graal/graal -s Final -f Karm/graal
[jbang] Building jar...
[INFO] Current version is 21.3.1.1
[INFO] New version will be 21.3.1.2
[INFO] Downloading mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz...
[INFO] Downloading mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz.sha1...
[INFO] Downloading mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz.sha256...
[INFO] Downloading mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz...
[INFO] Downloading mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz.sha1...
[INFO] Downloading mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz.sha256...
[INFO] Downloading mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz...
[INFO] Downloading mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz.sha1...
[INFO] Downloading mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz.sha256...
[INFO] Downloading mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz...
[INFO] Downloading mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz.sha1...
[INFO] Downloading mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz.sha256...
[INFO] Downloading mandrel-java11-windows-amd64-21.3.1.1-Final.zip...
[INFO] Downloading mandrel-java11-windows-amd64-21.3.1.1-Final.zip.sha1...
[INFO] Downloading mandrel-java11-windows-amd64-21.3.1.1-Final.zip.sha256...
[INFO] Downloading mandrel-java17-windows-amd64-21.3.1.1-Final.zip...
[INFO] Downloading mandrel-java17-windows-amd64-21.3.1.1-Final.zip.sha1...
[INFO] Downloading mandrel-java17-windows-amd64-21.3.1.1-Final.zip.sha256...
[INFO] Getting merged PRs for 21.3.1.1-Final (34)
21.3.1.1-Final
21.3.1.0-Final
[INFO] Uploading mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz
[INFO] Uploaded mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz
[INFO] Uploading mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz.sha1
[INFO] Uploaded mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz.sha1
[INFO] Uploading mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz.sha256
[INFO] Uploaded mandrel-java11-linux-amd64-21.3.1.1-Final.tar.gz.sha256
[INFO] Uploading mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz
[INFO] Uploaded mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz
[INFO] Uploading mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz.sha1
[INFO] Uploaded mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz.sha1
[INFO] Uploading mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz.sha256
[INFO] Uploaded mandrel-java11-linux-aarch64-21.3.1.1-Final.tar.gz.sha256
[INFO] Uploading mandrel-java11-windows-amd64-21.3.1.1-Final.zip
[INFO] Uploaded mandrel-java11-windows-amd64-21.3.1.1-Final.zip
[INFO] Uploading mandrel-java11-windows-amd64-21.3.1.1-Final.zip.sha1
[INFO] Uploaded mandrel-java11-windows-amd64-21.3.1.1-Final.zip.sha1
[INFO] Uploading mandrel-java11-windows-amd64-21.3.1.1-Final.zip.sha256
[INFO] Uploaded mandrel-java11-windows-amd64-21.3.1.1-Final.zip.sha256
[INFO] Uploading mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz
[INFO] Uploaded mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz
[INFO] Uploading mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz.sha1
[INFO] Uploaded mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz.sha1
[INFO] Uploading mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz.sha256
[INFO] Uploaded mandrel-java17-linux-amd64-21.3.1.1-Final.tar.gz.sha256
[INFO] Uploading mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz
[INFO] Uploaded mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz
[INFO] Uploading mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz.sha1
[INFO] Uploaded mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz.sha1
[INFO] Uploading mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz.sha256
[INFO] Uploaded mandrel-java17-linux-aarch64-21.3.1.1-Final.tar.gz.sha256
[INFO] Uploading mandrel-java17-windows-amd64-21.3.1.1-Final.zip
[INFO] Uploaded mandrel-java17-windows-amd64-21.3.1.1-Final.zip
[INFO] Uploading mandrel-java17-windows-amd64-21.3.1.1-Final.zip.sha1
[INFO] Uploaded mandrel-java17-windows-amd64-21.3.1.1-Final.zip.sha1
[INFO] Uploading mandrel-java17-windows-amd64-21.3.1.1-Final.zip.sha256
[INFO] Uploaded mandrel-java17-windows-amd64-21.3.1.1-Final.zip.sha256
[INFO] Created new draft release: https://github.com/graalvm/mandrel/releases/tag/untagged-383e5f7dfced84c9e3fb
[INFO] Please review and publish!
[INFO] Closed milestone 21.3.1.1-Final (34)
[INFO] Created milestone 21.3.1.2-Final (36)
[INFO] Git remote mandrel-release-fork points to git@github.com:Karm/graal
[WARN] Ref develop/mandrel-21.3.1.2-Final already exists
[INFO] Checked out develop/mandrel-21.3.1.2-Final
[WARN] develop/mandrel-21.3.1.2-Final reset (hard) to mandrel/21.3
[INFO] Updating /home/karm/workspaceRH/graal/graal/espresso/mx.espresso/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/compiler/mx.compiler/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/java-benchmarks/mx.java-benchmarks/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/sdk/mx.sdk/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/substratevm/mx.substratevm/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/tools/mx.tools/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/truffle/mx.truffle/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/vm/mx.vm/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/sulong/mx.sulong/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/regex/mx.regex/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/wasm/mx.wasm/suite.py
[INFO] Updating /home/karm/workspaceRH/graal/graal/examples/mx.examples/suite.py
[INFO] Updated suites
[INFO] Changes commited
[INFO] Changes pushed to remote mandrel-release-fork
[INFO] Checked out mandrel/21.3
[INFO] Pull request https://github.com/graalvm/mandrel/pull/367 created

```

Next: SDKMan api wrap up