### PR TITLE
Q version bump, free memory logged before test

### DIFF
--- a/jenkins/jobs/builds/mandrel_graal_vm_21_3_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_graal_vm_21_3_linux_build_matrix.groovy
@@ -1,6 +1,7 @@
 final Class Constants = new GroovyClassLoader(getClass().getClassLoader())
         .parseClass(readFileFromWorkspace("jenkins/jobs/builds/Constants.groovy"))
 matrixJob('mandrel-graal-vm-21-3-linux-build-matrix') {
+    disabled()
     axes {
         labelExpression('LABEL', ['el8_aarch64', 'el8'])
         text('JDK_VERSION',

--- a/jenkins/jobs/builds/mandrel_graal_vm_21_3_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_graal_vm_21_3_windows_build_matrix.groovy
@@ -1,6 +1,7 @@
 final Class Constants = new GroovyClassLoader(getClass().getClassLoader())
         .parseClass(readFileFromWorkspace("jenkins/jobs/builds/Constants.groovy"))
 matrixJob('mandrel-graal-vm-21-3-windows-build-matrix') {
+    disabled()
     axes {
         labelExpression('LABEL', ['w2k19'])
         text('JDK_VERSION',

--- a/jenkins/jobs/builds/mandrel_graal_vm_22_1_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_graal_vm_22_1_linux_build_matrix.groovy
@@ -1,6 +1,7 @@
 final Class Constants = new GroovyClassLoader(getClass().getClassLoader())
         .parseClass(readFileFromWorkspace("jenkins/jobs/builds/Constants.groovy"))
 matrixJob('mandrel-graal-vm-22-1-linux-build-matrix') {
+    disabled()
     axes {
         labelExpression('LABEL', ['el8_aarch64', 'el8'])
         text('JDK_VERSION',

--- a/jenkins/jobs/builds/mandrel_graal_vm_22_1_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_graal_vm_22_1_windows_build_matrix.groovy
@@ -1,6 +1,7 @@
 final Class Constants = new GroovyClassLoader(getClass().getClassLoader())
         .parseClass(readFileFromWorkspace("jenkins/jobs/builds/Constants.groovy"))
 matrixJob('mandrel-graal-vm-22-1-windows-build-matrix') {
+    disabled()
     axes {
         labelExpression('LABEL', ['w2k19'])
         text('JDK_VERSION',

--- a/jenkins/jobs/tests/Constants.groovy
+++ b/jenkins/jobs/tests/Constants.groovy
@@ -2,7 +2,7 @@ class Constants {
     static final ArrayList<String> QUARKUS_VERSION_RELEASED =
             [
                     '2.2.5.Final',
-                    '2.8.2.Final',
+                    '2.9.1.Final',
                     '2.7.5.Final'
             ]
 
@@ -14,7 +14,7 @@ class Constants {
 
     static final ArrayList<String> QUARKUS_VERSION_BUILDER_IMAGE =
             [
-                    '2.8.2.Final',
+                    '2.9.1.Final',
                     '2.7.5.Final'
             ]
 
@@ -68,6 +68,8 @@ class Constants {
     '''
 
     static final String LINUX_CONTAINER_INTEGRATION_TESTS = '''
+    free -h
+    df -h
     export CONTAINER_RUNTIME=podman
     source /etc/profile.d/jdks.sh
     set +e
@@ -90,6 +92,8 @@ class Constants {
     '''
 
     static final String LINUX_CONTAINER_QUARKUS_TESTS = '''
+    free -h
+    df -h
     git clone --depth 1 --branch ${QUARKUS_VERSION} ${QUARKUS_REPO}
     cd quarkus
     source /etc/profile.d/jdks.sh

--- a/jenkins/jobs/tests/mandrel_linux_container_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_container_integration_tests.groovy
@@ -3,11 +3,10 @@ final Class Constants = new GroovyClassLoader(getClass().getClassLoader())
 matrixJob('mandrel-linux-container-integration-tests') {
     axes {
         text('BUILDER_IMAGE',
-                'quay.io/quarkus/ubi-quarkus-mandrel:21.2-java11',
                 'quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11',
                 'quay.io/quarkus/ubi-quarkus-mandrel:21.3-java17',
-                'quay.io/quarkus/ubi-quarkus-mandrel:22.0-java11',
-                'quay.io/quarkus/ubi-quarkus-mandrel:22.0-java17'
+                'quay.io/quarkus/ubi-quarkus-mandrel:22.1-java11',
+                'quay.io/quarkus/ubi-quarkus-mandrel:22.1-java17'
         )
         text('QUARKUS_VERSION', Constants.QUARKUS_VERSION_RELEASED)
         labelExpression('LABEL', ['el8'])

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_container_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_container_tests.groovy
@@ -5,8 +5,8 @@ matrixJob('mandrel-linux-quarkus-container-tests') {
         text('BUILDER_IMAGE',
                 'quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11',
                 'quay.io/quarkus/ubi-quarkus-mandrel:21.3-java17',
-                'quay.io/quarkus/ubi-quarkus-mandrel:22.0-java11',
-                'quay.io/quarkus/ubi-quarkus-mandrel:22.0-java17'
+                'quay.io/quarkus/ubi-quarkus-mandrel:22.1-java11',
+                'quay.io/quarkus/ubi-quarkus-mandrel:22.1-java17'
         )
         text('QUARKUS_VERSION', Constants.QUARKUS_VERSION_BUILDER_IMAGE)
         labelExpression('LABEL', ['el8'])


### PR DESCRIPTION
Q version bump.
Some logging of free mem before tests.
Disables jobs on the abandoned auto merged branch.
A new -dev branch will replace that.