### PR TITLE
Don't remove org.graalvm.compiler.truffle.compiler.hotspot.amd64

### DIFF
--- a/build.java
+++ b/build.java
@@ -1051,7 +1051,7 @@ class Mx
             "\"org.graalvm.compiler.truffle.runtime.hotspot\",",
             "\"org.graalvm.compiler.truffle.runtime.hotspot.java\",",
             "\"org.graalvm.compiler.truffle.runtime.hotspot.libgraal\",",
-            "\"org.graalvm.compiler.truffle.compiler.hotspot.amd64\",",
+            // "\"org.graalvm.compiler.truffle.compiler.hotspot.amd64\",", required by com.oracle.svm.core.meta.ObjectConstantEquality
             "\"org.graalvm.compiler.truffle.compiler.hotspot.aarch64\",",
             "\"org.graalvm.compiler.truffle.jfr\",",
             // "\"truffle:TRUFFLE_API\"", Keep this as there are deps on it


### PR DESCRIPTION
Works around issue https://github.com/graalvm/mandrel/issues/387 until https://github.com/oracle/graal/pull/4633 gets merged.

Closes https://github.com/graalvm/mandrel/issues/387