### PR TITLE
Revert "Don't remove org.graalvm.compiler.truffle.compiler.hotspot.amd64"

### DIFF
--- a/build.java
+++ b/build.java
@@ -1052,7 +1052,7 @@ class Mx
             "\"org.graalvm.compiler.truffle.runtime.hotspot\",",
             "\"org.graalvm.compiler.truffle.runtime.hotspot.java\",",
             "\"org.graalvm.compiler.truffle.runtime.hotspot.libgraal\",",
-            // "\"org.graalvm.compiler.truffle.compiler.hotspot.amd64\",", required by com.oracle.svm.core.meta.ObjectConstantEquality
+            "\"org.graalvm.compiler.truffle.compiler.hotspot.amd64\",",
             "\"org.graalvm.compiler.truffle.compiler.hotspot.aarch64\",",
             "\"org.graalvm.compiler.truffle.jfr\",",
             // "\"truffle:TRUFFLE_API\"", Keep this as there are deps on it


### PR DESCRIPTION
Reverts #251 now that https://github.com/oracle/graal/pull/4633 has been merged upstream.

This reverts commit 9cebc275fe0a608451c881413d4ced6f89263be6.