### PR TITLE
Clean up dependency removals and further reduce Mandrel's dependencies

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -109,6 +109,7 @@ jobs:
         path: mandrel-java11-linux-amd64.tar.gz
     - name: Build Mandrel JDK with tarxz suffix
       run: |
+        git -C ${MANDREL_REPO} checkout .
         ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tarxz --skip-clean --skip-java --skip-native
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
         export ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
@@ -283,6 +284,7 @@ jobs:
         --maven-repo-id myRepo \
         --maven-url "file:///tmp/myRepo" \
         --mandrel-home temp-build
+        git -C ${MANDREL_REPO} checkout .
         # Build the native bits
         ./temp-build/bin/java -ea build.java \
         --verbose \

--- a/build.java
+++ b/build.java
@@ -308,6 +308,10 @@ public class build
                         " -Dorg.graalvm.version=\"" + mandrelVersion + "\"" +
                         " -Dorg.graalvm.config=\"Mandrel Distribution\"" +
                         launcherMatcher.group(2);
+                // Drop truffle module related parts
+                launcherLine = launcherLine.replace("org.graalvm.truffle,", "")
+                    .replace("%location%\\..\\..\\truffle\\truffle-api.jar:", "")
+                    .replace("${location}/../../truffle/truffle-api.jar:", "");
                 lines.set(i, launcherLine);
                 logger.debugf("Launcher line AFTER: %s", lines.get(i));
                 break;
@@ -529,12 +533,15 @@ class SequentialBuild
     {
         final Tasks.Exec.Effects exec = new Tasks.Exec.Effects(task -> os.exec(task, false));
         final Tasks.FileReplace.Effects replace = Tasks.FileReplace.Effects.ofSystem();
+        LOG.debugf("Patch sources to remove dependency on truffle-api.jar ...");
+        String patchPath = fs.workingDir().resolve(Path.of("resources", "truffle-api-removal.patch")).toString();
+        exec.exec.accept(Tasks.Exec.of(List.of("git", "apply", patchPath), fs.mandrelRepo()));
         Mx.build(options, exec, replace, fs.mxHome(), fs.mandrelRepo(), os.javaHome());
         if (options.mavenDeploy && !options.skipJava)
         {
             // Create wrapper jar file for archiving resources (e.g. native image launcher script)
             LOG.debugf("Patch sdk suite.py ...");
-            String patchPath = fs.workingDir().resolve(Path.of("resources", "mandrel-packaging-wrapper.patch")).toString();
+            patchPath = fs.workingDir().resolve(Path.of("resources", "mandrel-packaging-wrapper.patch")).toString();
             exec.exec.accept(Tasks.Exec.of(List.of("git", "apply", patchPath), fs.mandrelRepo()));
             LOG.debugf("Build Mandrel's wrapper jar...");
             Mx.BuildArgs buildArgs = Mx.BuildArgs.of("--only", "MANDREL_PACKAGING_WRAPPER");
@@ -784,8 +791,6 @@ class Mx
                         new Path[]{substrateDistPath.resolve("pointsto.jar"), Path.of("lib", "svm", "builder", "pointsto.jar")}),
                 new SimpleEntry<>("org.graalvm.nativeimage:library-support.jar",
                         new Path[]{substrateDistPath.resolve("library-support.jar"), Path.of("lib", "svm", "library-support.jar")}),
-                new SimpleEntry<>("org.graalvm.truffle:truffle-api.jar",
-                        new Path[]{truffleDistPath.resolve("truffle-api.jar"), Path.of("lib", "truffle", "truffle-api.jar")}),
                 new SimpleEntry<>("org.graalvm.compiler:compiler.jar",
                         new Path[]{compilerDistPath.resolve("graal.jar"), Path.of("lib", "jvmci", "graal.jar")}),
                 new SimpleEntry<>("org.graalvm.nativeimage:objectfile.jar",
@@ -816,7 +821,6 @@ class Mx
                 "NATIVE_IMAGE_BASE," +
                 "POINTSTO," +
                 "LIBRARY_SUPPORT," +
-                "TRUFFLE_API," +
                 "GRAAL," +
                 "OBJECTFILE," +
                 "SVM_DRIVER," +
@@ -1020,19 +1024,13 @@ class Mx
         Path suitePy = Path.of("substratevm", "mx.substratevm", "suite.py");
         Path path = mandrelRepo.resolve(suitePy);
         Map<String, String> dependenciesToPatch = Map.ofEntries(
+            // Mandrel doesn't use Graal at runtime but requires some stubs declared in the package
+            // new SimpleEntry<>("^ +\"com.oracle.svm.graal\",", ""),
             // Mandrel doesn't use truffle
             new SimpleEntry<>("^ +\"com.oracle.svm.truffle\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.svm.truffle.api                   to org.graalvm.truffle\",", ""),
+            new SimpleEntry<>("^ +\"com.oracle.svm.truffle.api +to org.graalvm.truffle\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.truffle.api.TruffleLanguage.Provider\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation.TruffleInstrument.Provider\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.svm.truffle.nfi\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.svm.truffle.nfi.posix\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.svm.truffle.nfi.windows\",", ""),
-            // new SimpleEntry<>("^ +com.oracle.svm.truffle.tck\",", ""),
-            // new SimpleEntry<>("^ +\"truffle:TRUFFLE_API\"", ""), // Keep this as there are deps on it
-            new SimpleEntry<>("^ +\"extracted-dependency:truffle:LIBFFI_DIST\"", ""),
-            new SimpleEntry<>("^ +\"extracted-dependency:truffle:TRUFFLE_NFI_GRAALVM_SUPPORT/include/trufflenfi.h\",", ""),
-            new SimpleEntry<>("^ +\"file:src/com.oracle.svm.libffi/include/svm_libffi.h\",", ""),
             // Mandrel doesn't use polyglot
             new SimpleEntry<>("^ +\"com.oracle.svm.polyglot\",", ""));
         Tasks.FileReplace.replace(
@@ -1052,20 +1050,12 @@ class Mx
         path = mandrelRepo.resolve(suitePy);
         dependenciesToPatch = Map.ofEntries(
             // Mandrel doesn't use libgraal
+            new SimpleEntry<>("^ +\"org.graalvm.libgraal +to jdk.internal.vm.compiler.management\",", ""),
             new SimpleEntry<>("^ +\"org.graalvm.libgraal\",", ""),
             new SimpleEntry<>("^ +\"org.graalvm.libgraal.jni\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.libgraal                        to jdk.internal.vm.compiler.management\",", ""),
             // Mandrel doesn't use truffle
-            // new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.amd64\",", ""), // Keep as it's needed by com.oracle.svm.core
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.serviceprovider\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot.java\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot.libgraal\",", ""),
-            // new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.hotspot.amd64\",", ""), // required by com.oracle.svm.core.meta.ObjectConstantEquality
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.hotspot.aarch64\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.jfr\",", ""),
-            // new SimpleEntry<>("^ +\"truffle:TRUFFLE_API\"", ""), // Keep this as there are deps on it
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.jfr            to jdk.internal.vm.compiler.truffle.jfr\",", ""),
+            new SimpleEntry<>("^ +\"truffle:TRUFFLE_API\",?", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.jfr +to jdk.internal.vm.compiler.truffle.jfr\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.truffle.api.impl.TruffleLocator\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.truffle.api.object.LayoutFactory\",", ""),
             new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.hotspot.TruffleCallBoundaryInstrumentationFactory\",", ""),
@@ -1073,6 +1063,15 @@ class Mx
             new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.LoopNodeFactory\",", ""),
             new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.TruffleTypes\",", ""),
             new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.EngineCacheSupport\",", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.jfr\",", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.amd64\",", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.serviceprovider\",", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot\",", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot.java\",", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot.libgraal\",", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.hotspot.amd64\",", ""),
+            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.hotspot.aarch64\",", ""),
+            // Mandrel doesn't use LLVM
             new SimpleEntry<>(",org.graalvm.nativeimage.llvm", ""));
         Tasks.FileReplace.replace(
             new Tasks.FileReplace(path, patchSuites(dependenciesToPatch))
@@ -1083,49 +1082,18 @@ class Mx
         path = mandrelRepo.resolve(suitePy);
         dependenciesToPatch = Map.of(
             // Mandrel doesn't use polyglot
-            // "^ +\"org.graalvm.polyglot\",", Keep as it's needed by TRUFFLE_API
+            // "^ +\"org.graalvm.polyglot\",", "", // Required by org.graalvm.nativebridge
             "^ +\"org.graalvm.polyglot.proxy\",", "",
-            // "^ +\"org.graalvm.polyglot.io\",", Keep as it's needed by TRUFFLE_API
+            "^ +\"org.graalvm.polyglot.io\",", "",
             "^ +\"org.graalvm.polyglot.management\",", "",
-            // "^ +\"org.graalvm.polyglot.impl to org.graalvm.truffle\",", Keep as it's needed by TRUFFLE_API
+            "^ +\"org.graalvm.polyglot.impl +to org.graalvm.truffle, com.oracle.graal.graal_enterprise\",", "",
             "^ +\"org.graalvm.polyglot.impl.AbstractPolyglotImpl\"", "",
-            "^ +\"org.graalvm.polyglot to org.graalvm.truffle\"", "");
+            "^ +\"org.graalvm.polyglot +to org.graalvm.truffle\"", "");
         Tasks.FileReplace.replace(
             new Tasks.FileReplace(path, patchSuites(dependenciesToPatch))
             , effects
         );
 
-        suitePy = Path.of("truffle", "mx.truffle", "suite.py");
-        path = mandrelRepo.resolve(suitePy);
-        dependenciesToPatch = Map.ofEntries(
-            // Mandrel doesn't use the full TRUFFLE_API
-            new SimpleEntry<>("^ +\"com.oracle.truffle.object to jdk.internal.vm.compiler, com.oracle.graal.graal_enterprise\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.library to com.oracle.truffle.truffle_nfi_libffi, com.oracle.truffle.truffle_nfi\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation.TruffleInstrument.Provider\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.library.DefaultExportProvider\",", ""),
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.library.EagerExportProvider\",", " ),// Keep as it's needed by TRUFFLE_API
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.source\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.memory\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.io\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.frame\",", ""),
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.object\",", " ),// Keep as it brings com.oracle.truffle.api.interop
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.exception\",", ""), // alternative that brings com.oracle.truffle.api.interop
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.dsl\",", " ),// Keep as it's needed by com.oracle.truffle.api.library
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.profiles\",", " ),// Keep as it's needed by com.oracle.truffle.api.interop
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.interop\",", " ),// Keep as it brings com.oracle.truffle.api.library
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.debug\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.utilities\",", ""),
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.object\",", " ),// Keep as it brings com.oracle.truffle.api.object
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.object.dsl\",", ""), // alternative that brings com.oracle.truffle.api.object
-            new SimpleEntry<>("^ +\"com.oracle.truffle.polyglot\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.host\",", ""),
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.library\",", " ),// Keep as it provides EagerExportProvider and is also needed by TRUFFLE_DSL_PROCESSOR which is needed by org.graalvm.compiler.truffle.options
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.staticobject\",", ""));
-        Tasks.FileReplace.replace(
-            new Tasks.FileReplace(path, patchSuites(dependenciesToPatch))
-            , effects
-        );
     }
 
     private static Function<Stream<String>, List<String>> patchSuites(Map<String, String> patches)

--- a/resources/truffle-api-removal.patch
+++ b/resources/truffle-api-removal.patch
@@ -1,0 +1,136 @@
+diff --git a/sdk/mx.sdk/mx_sdk_vm_impl.py b/sdk/mx.sdk/mx_sdk_vm_impl.py
+index 43456a4778a..23763ed758b 100644
+--- a/sdk/mx.sdk/mx_sdk_vm_impl.py
++++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
+@@ -1296,7 +1296,6 @@ class NativePropertiesBuildTask(mx.ProjectBuildTask):
+             build_args = [
+                 '--no-fallback',
+                 '-H:+AssertInitializationSpecifiedForAllClasses',
+-                '-H:+EnforceMaxRuntimeCompileMethods',
+                 '-Dorg.graalvm.version={}'.format(_suite.release_version()),
+             ]
+             if _debug_images():
+diff --git a/substratevm/mx.substratevm/mx_substratevm.py b/substratevm/mx.substratevm/mx_substratevm.py
+index cd1a158934c..bb2d31a7569 100644
+--- a/substratevm/mx.substratevm/mx_substratevm.py
++++ b/substratevm/mx.substratevm/mx_substratevm.py
+@@ -238,7 +238,7 @@ def run_musl_basic_tests():
+ @contextmanager
+ def native_image_context(common_args=None, hosted_assertions=True, native_image_cmd='', config=None, build_if_missing=False):
+     common_args = [] if common_args is None else common_args
+-    base_args = ['--no-fallback', '-H:+EnforceMaxRuntimeCompileMethods']
++    base_args = ['--no-fallback']
+     base_args += ['-H:Path=' + svmbuild_dir()]
+     if mx.get_opts().verbose:
+         base_args += ['--verbose']
+@@ -1057,7 +1057,7 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
+ ))
+ 
+ # GR-34811
+-llvm_supported = not (mx.is_windows() or (mx.is_darwin() and mx.get_arch() == "aarch64"))
++llvm_supported = False
+ if llvm_supported:
+     mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
+         suite=suite,
+diff --git a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+index c10b42d7da8..23932800490 100644
+--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
++++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+@@ -502,7 +502,6 @@ public class NativeImage {
+             // Non-jlinked JDKs need truffle and graal-sdk on the module path since they
+             // don't have those modules as part of the JDK.
+             result.addAll(getJars(rootDir.resolve(Paths.get("lib", "jvmci")), "graal-sdk", "enterprise-graal"));
+-            result.addAll(getJars(rootDir.resolve(Paths.get("lib", "truffle")), "truffle-api"));
+             if (modulePathBuild) {
+                 result.addAll(getJars(rootDir.resolve(Paths.get("lib", "svm", "builder"))));
+             }
+diff --git a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
+index 17cab5d9d6b..8ceba282e2c 100644
+--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
++++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
+@@ -75,7 +75,6 @@ import org.graalvm.compiler.phases.common.IterativeConditionalEliminationPhase;
+ import org.graalvm.compiler.phases.common.inlining.InliningUtil;
+ import org.graalvm.compiler.phases.tiers.Suites;
+ import org.graalvm.compiler.phases.util.Providers;
+-import org.graalvm.compiler.truffle.compiler.phases.DeoptimizeOnExceptionPhase;
+ import org.graalvm.compiler.word.WordTypes;
+ import org.graalvm.nativeimage.ImageSingletons;
+ import org.graalvm.nativeimage.hosted.Feature;
+@@ -557,9 +556,6 @@ public final class GraalFeature implements Feature {
+
+                 CanonicalizerPhase canonicalizer = CanonicalizerPhase.create();
+                 canonicalizer.apply(graph, hostedProviders);
+-                if (deoptimizeOnExceptionPredicate != null) {
+-                    new DeoptimizeOnExceptionPhase(deoptimizeOnExceptionPredicate).apply(graph);
+-                }
+                 new ConvertDeoptimizeToGuardPhase(canonicalizer).apply(graph, hostedProviders);
+
+                 graphEncoder.prepare(graph);
+diff --git a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/RuntimeCodeInstaller.java b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/RuntimeCodeInstaller.java
+index 292e18f7c64..737072594bd 100644
+--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/RuntimeCodeInstaller.java
++++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/RuntimeCodeInstaller.java
+@@ -34,7 +34,6 @@ import org.graalvm.compiler.code.CompilationResult.CodeAnnotation;
+ import org.graalvm.compiler.core.common.NumUtil;
+ import org.graalvm.compiler.debug.DebugContext;
+ import org.graalvm.compiler.debug.Indent;
+-import org.graalvm.compiler.truffle.common.TruffleCompiler;
+ import org.graalvm.nativeimage.ImageSingletons;
+ import org.graalvm.nativeimage.c.type.CTypeConversion;
+ import org.graalvm.word.Pointer;
+@@ -108,7 +107,7 @@ public class RuntimeCodeInstaller extends AbstractRuntimeCodeInstaller {
+     protected RuntimeCodeInstaller(SharedRuntimeMethod method, CompilationResult compilation) {
+         this.method = method;
+         this.compilation = (SubstrateCompilationResult) compilation;
+-        this.tier = compilation.getName().endsWith(TruffleCompiler.FIRST_TIER_COMPILATION_SUFFIX) ? TruffleCompiler.FIRST_TIER_INDEX : TruffleCompiler.LAST_TIER_INDEX;
++        this.tier = 1;
+         this.debug = new DebugContext.Builder(RuntimeOptionValues.singleton()).build();
+     }
+
+diff --git a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedCodeInstallBridge.java b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedCodeInstallBridge.java
+index e1bacdbc940..81ad2533f74 100644
+--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedCodeInstallBridge.java
++++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedCodeInstallBridge.java
+@@ -24,9 +24,6 @@
+  */
+ package com.oracle.svm.graal.isolated;
+
+-import org.graalvm.compiler.truffle.common.CompilableTruffleAST;
+-import org.graalvm.compiler.truffle.common.OptimizedAssumptionDependency;
+-
+ import com.oracle.svm.core.deopt.SubstrateInstalledCode;
+ import com.oracle.svm.core.util.VMError;
+
+@@ -37,7 +34,7 @@ import jdk.vm.ci.code.InstalledCode;
+  * compilation. It does not implement {@link InstalledCode} or {@link OptimizedAssumptionDependency}
+  * in any meaningful way.
+  */
+-public final class IsolatedCodeInstallBridge extends InstalledCode implements OptimizedAssumptionDependency {
++public final class IsolatedCodeInstallBridge extends InstalledCode {
+     private final ClientHandle<? extends SubstrateInstalledCode.Factory> factoryHandle;
+     private ClientHandle<? extends SubstrateInstalledCode> installedCodeHandle;
+
+@@ -87,23 +84,8 @@ public final class IsolatedCodeInstallBridge extends InstalledCode implements Op
+         throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
+     }
+
+-    @Override
+-    public void onAssumptionInvalidated(Object source, CharSequence reason) {
+-        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
+-    }
+-
+     @Override
+     public Object executeVarargs(Object... args) {
+         throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
+     }
+-
+-    @Override
+-    public CompilableTruffleAST getCompilable() {
+-        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
+-    }
+-
+-    @Override
+-    public boolean soleExecutionEntryPoint() {
+-        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
+-    }
+ }


### PR DESCRIPTION
Completely drops the TRUFFLE_API dependency (and thus the `TRUFFLE_JCODINGS` one introduced in https://github.com/oracle/graal/commit/5d52020fb4565926a01f870847fe2218aa348e72 as well), with the drawback that it requires some source code patching in `com.oracle.svm.graal`.