### PR TITLE
Don't perform any Python version checking in mandrel-packaging

### DIFF
--- a/build.java
+++ b/build.java
@@ -1009,7 +1009,7 @@ class Mx
     private static Tasks.Exec execTask(List<String> args, Path directory, EnvVar... envVars)
     {
         final EnvVar[] mxEnvVars = new EnvVar[envVars.length + 1];
-        mxEnvVars[0] = new EnvVar("MX_PYTHON", "python");
+        mxEnvVars[0] = new EnvVar("MX_PYTHON", Python.get());
         System.arraycopy(envVars, 0, mxEnvVars, 1, envVars.length);
         return Tasks.Exec.of(args, directory, mxEnvVars);
     }
@@ -1780,12 +1780,6 @@ final class Check
 
     static void checkMx() throws IOException
     {
-        final Process p = new ProcessBuilder("python", "--version").redirectErrorStream(true).start();
-        try (InputStream is = p.getInputStream()) {
-            if(!(new String(is.readAllBytes(), StandardCharsets.UTF_8)).contains("Python 3")) {
-                throw new RuntimeException("python command must point to Python 3");
-            }
-        }
         final Options options = Options.from(Args.read("--maven-version-suffix", ".redhat-00001"));
         final RecordingOperatingSystem os = new RecordingOperatingSystem();
         final Tasks.Exec.Effects exec = new Tasks.Exec.Effects(os::record);
@@ -1850,4 +1844,15 @@ final class Check
             tasks.remove();
         }
     }
+}
+
+final class Python {
+
+    static String get()
+    {
+        // Use MX_PYTHON if set, otherwise use 'python'
+        String mxPython = System.getenv("MX_PYTHON");
+        return mxPython == null ? "python" : mxPython;
+    }
+
 }


### PR DESCRIPTION
https://github.com/graalvm/mandrel-packaging/pull/252 broke systems where there is no `python` in the `$PATH`. For example on some RHEL 8 systems with only python 3 installed, there is only a `python3` binary in `$PATH` one limitation of that system is that it cannot add symlinks in `$PATH` (neither with regular symlinks nor with `alternatives`; that's by design of `rpmbuild`). That breaks the build with exceptions like these:

```
Exception in thread "main" java.io.IOException: Cannot run program "python": error=2, No such file or directory
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
	at Check.checkMx(build.java:1751)
	at Check.main(build.java:1746)
	at build.main(build.java:51)
Caused by: java.io.IOException: error=2, No such file or directory
	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:314)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:244)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1110)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
	at Check.checkMx(build.java:1751)
	at Check.main(build.java:1746)
	at build.main(build.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.execute(Main.java:419)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.run(Main.java:192)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:132)
```

Previously we were able to set `MX_PYTHON` which would then be used as the python binary for `mx`, no questions asked. #252 breaks this by assuming `python` is there. The proposed solution is to use `python` as before **iff** `MX_PYTHON` is **not** set. If it is use the binary pointed to by `MX_PYTHON`.