### PR TITLE
Use MX_PYTHON for python path if set

### DIFF
--- a/build.java
+++ b/build.java
@@ -1013,7 +1013,7 @@ class Mx
     private static Tasks.Exec execTask(List<String> args, Path directory, EnvVar... envVars)
     {
         final EnvVar[] mxEnvVars = new EnvVar[envVars.length + 1];
-        mxEnvVars[0] = new EnvVar("MX_PYTHON", "python");
+        mxEnvVars[0] = new EnvVar("MX_PYTHON", Python.get());
         System.arraycopy(envVars, 0, mxEnvVars, 1, envVars.length);
         return Tasks.Exec.of(args, directory, mxEnvVars);
     }
@@ -1748,12 +1748,6 @@ final class Check
 
     static void checkMx() throws IOException
     {
-        final Process p = new ProcessBuilder("python", "--version").redirectErrorStream(true).start();
-        try (InputStream is = p.getInputStream()) {
-            if(!(new String(is.readAllBytes(), StandardCharsets.UTF_8)).contains("Python 3")) {
-                throw new RuntimeException("python command must point to Python 3");
-            }
-        }
         final Options options = Options.from(Args.read("--maven-version-suffix", ".redhat-00001"));
         final RecordingOperatingSystem os = new RecordingOperatingSystem();
         final Tasks.Exec.Effects exec = new Tasks.Exec.Effects(os::record);
@@ -1818,4 +1812,15 @@ final class Check
             tasks.remove();
         }
     }
+}
+
+final class Python {
+
+    static String get()
+    {
+        // Use MX_PYTHON if set, otherwise use 'python'
+        String mxPython = System.getenv("MX_PYTHON");
+        return mxPython == null ? "python" : mxPython;
+    }
+
 }


### PR DESCRIPTION
Don't perform a version check on the set python
binary. MX does it for us.

Closes #266

Cherry-pick from master.