### PR TITLE
Process: Collect stdErr, spit output if there is an error

### DIFF
--- a/build.java
+++ b/build.java
@@ -1,6 +1,4 @@
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -27,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Scanner;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -37,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class build
@@ -1610,6 +1610,7 @@ class OperatingSystem
     List<String> exec(Tasks.Exec task, boolean getOutput)
     {
         LOG.debugf("Execute %s in %s with environment variables %s", task.args, task.directory, task.envVars);
+        File outputFile = null;
         try
         {
             List<String> s = new ArrayList<>();
@@ -1628,28 +1629,37 @@ class OperatingSystem
                     .put(envVar.name, envVar.value)
             );
 
-            File outputFile = null;
             if (getOutput)
             {
                 outputFile = File.createTempFile("mandrel-builder-exec-output", "txt");
                 outputFile.deleteOnExit();
+                processBuilder.redirectErrorStream(true);
                 processBuilder.redirectOutput(outputFile);
             }
-            Process process = processBuilder.start();
-
+            final Process process = processBuilder.start();
             if (process.waitFor() != 0)
             {
+                if (outputFile != null && outputFile.exists() && Logger.debug)
+                {
+                    try (Scanner sc = new Scanner(outputFile.toPath(), UTF_8))
+                    {
+                        while (sc.hasNextLine())
+                        {
+                            LOG.debugf(sc.nextLine());
+                        }
+                    }
+                    catch (IOException ex)
+                    {
+                        throw new RuntimeException(ex);
+                    }
+                }
                 throw new RuntimeException(
                     "Failed, exit code: " + process.exitValue()
                 );
             }
-
             if (getOutput)
             {
-                final BufferedReader bufferedReader = new BufferedReader(new FileReader(outputFile));
-                List<String> result = bufferedReader.lines().collect(Collectors.toList());
-                bufferedReader.close();
-                return result;
+                return Files.readAllLines(outputFile.toPath());
             }
             return null;
         }


### PR DESCRIPTION
When running on Jenkins, the stderr is muted, e.g. this should have spitted out that there was a problem with Pyhton version, but it didn't:

```
+ /usr/lib/jvm/java/bin/java -ea mandrel-packaging/build.java --maven-local-repository /home/tester/.m2/repository --mandrel-repo /mnt/ramdisk/mandrel-build/mandrel --mx-home /mnt/ramdisk/mandrel-build/mx --mandrel-version ec9ecc50b45 --mandrel-home /mnt/ramdisk/mandrel-build/mandrel-packaging/mandrelJDK --mandrel-packaging-home /mnt/ramdisk/mandrel-build/mandrel-packaging --archive-suffix tarxz
Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: Failed, exit code: 1
	at OperatingSystem.exec(build.java:1658)
	at Mx.<init>(build.java:775)
	at build.main(build.java:55)
Caused by: java.lang.RuntimeException: Failed, exit code: 1
	at OperatingSystem.exec(build.java:1643)
	at Mx.<init>(build.java:775)
	at build.main(build.java:55)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.execute(Main.java:419)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.run(Main.java:192)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:132)
```


Whereas with this patch, we get the error cause too, e.g.:

```
DEBUG [OperatingSystem] mx requires python 3.8+, not 2.7.18 (/home/karm/.pyenv/versions/2.7.18/bin/python)
DEBUG [OperatingSystem] The path to the Python interpreter can be specified with the MX_PYTHON environment variable.
```