### PR TITLE
Adjust truffle-api-removal.patch for latest upstream 22.3 branch

### DIFF
--- a/resources/truffle-api-removal.patch
+++ b/resources/truffle-api-removal.patch
@@ -102,7 +102,7 @@ index e1bacdbc940..81ad2533f74 100644
      private final ClientHandle<? extends SubstrateInstalledCode.Factory> factoryHandle;
      private ClientHandle<? extends SubstrateInstalledCode> installedCodeHandle;
  
-@@ -87,23 +84,8 @@ public final class IsolatedCodeInstallBridge extends InstalledCode implements Op
+@@ -87,19 +84,9 @@ public final class IsolatedCodeInstallBridge extends InstalledCode implements Op
          throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
      }
  
@@ -115,14 +115,10 @@ index e1bacdbc940..81ad2533f74 100644
      public Object executeVarargs(Object... args) {
          throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
      }
--
+ 
 -    @Override
 -    public CompilableTruffleAST getCompilable() {
 -        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
 -    }
 -
--    @Override
--    public boolean soleExecutionEntryPoint() {
--        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
--    }
  }


### PR DESCRIPTION
Currently, the build fails for me on the recent 22.3 dev branch (revision `40f4b754d9bc200108a956cb45afbb9fae9e6ab6`) with:

```
DEBUG [OperatingSystem] Execute [git, apply, /disk/graal/upstream-sources/mandrel-packaging/resources/truffle-api-removal.patch] in /disk/graal/upstream-sources/graalvm with environment variables []
error: patch failed: substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedCodeInstallBridge.java:87
error: substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedCodeInstallBridge.java: patch does not apply
Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: Failed, exit code: 1
	at OperatingSystem.exec(build.java:1646)
	at SequentialBuild.lambda$build$0(build.java:534)
	at SequentialBuild.build(build.java:538)
	at build.main(build.java:73)
Caused by: java.lang.RuntimeException: Failed, exit code: 1
	at OperatingSystem.exec(build.java:1631)
	at SequentialBuild.lambda$build$0(build.java:534)
	at SequentialBuild.build(build.java:538)
	at build.main(build.java:73)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.execute(Main.java:419)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.run(Main.java:192)
	at jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:132)
```

Seems to be caused by https://github.com/oracle/graal/commit/9ff7aeab2e4ab4619a60d7d1bd2994ba52de66b6#diff-598736e4dafa70c4a2df8c59f9ecbaedcdbd532be8c3495148543277abc79d21 which got added on the 22.3 branch.