### PR TITLE
Major refactoring of release script

### DIFF
--- a/release-scripts/mandrel-release.java
+++ b/release-scripts/mandrel-release.java
@@ -508,6 +508,12 @@ class GitHubOps
      */
     private String getLatestReleasedTag(List<GHTag> tags)
     {
+        // Figuring out the last released Tag for pre-releases is not trivial so
+        // just return null and let the user manually update the release notes
+        if (!version.suffix.equals("Final"))
+        {
+            return null;
+        }
         final String tagPrefix = "mandrel-";
         List<MandrelVersion> finalVersions = tags.stream()
             .filter(x -> x.getName().startsWith(tagPrefix + version.majorMinorMicro()) && x.getName().endsWith("Final"))

--- a/release-scripts/mandrel-release.java
+++ b/release-scripts/mandrel-release.java
@@ -124,17 +124,8 @@ class MandrelRelease
 
     public Integer call() throws IOException
     {
+        checkOptions();
         // Prepare version
-        if (!suffix.equals("Final") && !Pattern.compile("^(Alpha|Beta)\\d*$").matcher(suffix).find())
-        {
-            Log.error("Invalid version suffix : " + suffix);
-        }
-
-        if (!Path.of(mandrelRepo).toFile().exists())
-        {
-            Log.error("Path " + mandrelRepo + " does not exist");
-        }
-
         version = getCurrentVersion();
         Log.info("Current version is " + version);
         version.suffix = suffix; // TODO: if Alpha/Beta autobump suffix number?
@@ -169,6 +160,19 @@ class MandrelRelease
         final String authorEmail = commitAndPushChanges();
         openPR(authorEmail);
         return 0;
+    }
+
+    void checkOptions()
+    {
+        if (!suffix.equals("Final") && !Pattern.compile("^(Alpha|Beta)\\d*$").matcher(suffix).find())
+        {
+            Log.error("Invalid version suffix : " + suffix);
+        }
+
+        if (!Path.of(mandrelRepo).toFile().exists())
+        {
+            Log.error("Path " + mandrelRepo + " does not exist");
+        }
     }
 
     private void checkAndPrepareRepository()

--- a/release-scripts/mandrel-release.java
+++ b/release-scripts/mandrel-release.java
@@ -126,7 +126,7 @@ class MandrelRelease
     {
         checkOptions();
         // Prepare version
-        version = getCurrentVersion();
+        version = MandrelVersion.ofRepository(mandrelRepo);
         Log.info("Current version is " + version);
         version.suffix = suffix; // TODO: if Alpha/Beta autobump suffix number?
 
@@ -457,36 +457,6 @@ class MandrelRelease
             e.printStackTrace();
             Log.error(e.getMessage());
         }
-    }
-
-    /**
-     * Returns current version of substratevm
-     *
-     * @return
-     */
-    private MandrelVersion getCurrentVersion()
-    {
-        final Path substrateSuite = Path.of(mandrelRepo, "substratevm", "mx.substratevm", "suite.py");
-        try
-        {
-            final List<String> lines = Files.readAllLines(substrateSuite);
-            final Pattern versionPattern = Pattern.compile("\"version\" : \"([\\d.]+)\"");
-            for (String line : lines)
-            {
-                final Matcher versionMatcher = versionPattern.matcher(line);
-                if (versionMatcher.find())
-                {
-                    final String version = versionMatcher.group(1);
-                    return new MandrelVersion(version);
-                }
-            }
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-            Log.error(e.getMessage());
-        }
-        return null;
     }
 
     private void createGHRelease() throws IOException
@@ -969,6 +939,36 @@ class MandrelVersion implements Comparable<MandrelVersion>
         micro = Integer.parseInt(versionMatcher.group(3));
         pico = Integer.parseInt(versionMatcher.group(4));
         suffix = versionMatcher.group(6);
+    }
+
+    /**
+     * Returns current version of substratevm
+     *
+     * @return
+     */
+    static MandrelVersion ofRepository(String mandrelRepo)
+    {
+        final Path substrateSuite = Path.of(mandrelRepo, "substratevm", "mx.substratevm", "suite.py");
+        try
+        {
+            final List<String> lines = Files.readAllLines(substrateSuite);
+            final Pattern versionPattern = Pattern.compile("\"version\" : \"([\\d.]+)\"");
+            for (String line : lines)
+            {
+                final Matcher versionMatcher = versionPattern.matcher(line);
+                if (versionMatcher.find())
+                {
+                    final String version = versionMatcher.group(1);
+                    return new MandrelVersion(version);
+                }
+            }
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+            Log.error(e.getMessage());
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
* Splits code into classes to group together related functionality
* Uses picocli subcommands instead of manually checking whether the user requested a "release" or "prepare" _phase_
  * This also enables us to have subcommand specific flags, e.g. `-d` doesn't make sense in `prepare`
* Decouples the code for each subcommand hopefully making it a bit easier to understand/follow what each command does

Probably best reviewed commit by commit.