### PR TITLE
Update Quarkus version and matrix in jenkins jobs

### DIFF
--- a/jenkins/jobs/tests/Constants.groovy
+++ b/jenkins/jobs/tests/Constants.groovy
@@ -8,8 +8,14 @@ class Constants {
     static final ArrayList<String> QUARKUS_VERSION_SHORT =
             [
                     '2.13.4.Final',
+                    '2.7.6.Final'
                     'main'
             ]
+
+    static final String QUARKUS_VERSION_SHORT_COMBINATION_FILTER =
+            '((QUARKUS_VERSION.startsWith("2.7") || QUARKUS_VERSION.startsWith("2.13")) && MANDREL_BUILD.startsWith("mandrel-21"))' +
+            '|| (QUARKUS_VERSION.startsWith("2.13") && MANDREL_BUILD.startsWith("mandrel-22") && JDK_VERSION.equals("17"))' +
+            '|| (QUARKUS_VERSION.equals("main") && !MANDREL_BUILD.startsWith("mandrel-21") && JDK_VERSION.equals("17"))'
 
     static final ArrayList<String> QUARKUS_VERSION_BUILDER_IMAGE =
             [

--- a/jenkins/jobs/tests/Constants.groovy
+++ b/jenkins/jobs/tests/Constants.groovy
@@ -1,19 +1,19 @@
 class Constants {
     static final ArrayList<String> QUARKUS_VERSION_RELEASED =
             [
-                    '2.13.3.Final',
+                    '2.13.4.Final',
                     '2.7.6.Final'
             ]
 
     static final ArrayList<String> QUARKUS_VERSION_SHORT =
             [
-                    '2.13.3.Final',
+                    '2.13.4.Final',
                     'main'
             ]
 
     static final ArrayList<String> QUARKUS_VERSION_BUILDER_IMAGE =
             [
-                    '2.13.3.Final',
+                    '2.13.4.Final',
                     '2.7.6.Final'
             ]
 

--- a/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
@@ -30,7 +30,7 @@ matrixJob('mandrel-22-3-windows-quarkus-tests') {
         }
     }
     combinationFilter(
-            '!(QUARKUS_VERSION.equals("main") && (MANDREL_BUILD.contains("mandrel-21") || JDK_VERSION.contains("11")))'
+            Constants.QUARKUS_VERSION_SHORT_COMBINATION_FILTER
     )
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
@@ -34,7 +34,7 @@ matrixJob('mandrel-linux-quarkus-subset-tests') {
         }
     }
     combinationFilter(
-            '!(QUARKUS_VERSION.equals("main") && (MANDREL_BUILD.contains("mandrel-21") || JDK_VERSION.contains("11")))'
+            Constants.QUARKUS_VERSION_SHORT_COMBINATION_FILTER
     )
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
@@ -32,7 +32,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
         }
     }
     combinationFilter(
-            '!(QUARKUS_VERSION.equals("main") && (MANDREL_BUILD.contains("mandrel-21") || JDK_VERSION.contains("11")))'
+            Constants.QUARKUS_VERSION_SHORT_COMBINATION_FILTER
     )
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')

--- a/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
@@ -32,7 +32,7 @@ matrixJob('mandrel-windows-quarkus-tests') {
         }
     }
     combinationFilter(
-            '!(QUARKUS_VERSION.equals("main") && (MANDREL_BUILD.contains("mandrel-21") || JDK_VERSION.contains("11")))'
+            Constants.QUARKUS_VERSION_SHORT_COMBINATION_FILTER
     )
     parameters {
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')


### PR DESCRIPTION
Bump Quarkus to 2.13.4.Final

Update test matrix to test the following combinations:

* Mandrel 21.3 with JDK 11 and 17, and Quarkus 2.7 and 2.13
* Mandrel 22.3 with JDK 17, and Quarkus 2.13 and `main`
* Mandrel master with JDK 17, and `main`