### PR TITLE
Jenkins: Skip test jobs if MANDREL_BUILD is not available

### DIFF
--- a/jenkins/jobs/tests/Constants.groovy
+++ b/jenkins/jobs/tests/Constants.groovy
@@ -36,6 +36,10 @@ class Constants {
             'bouncycastle-jsse,' +
             'bouncycastle'
 
+    static final String LINUX_CHECK_MANDREL_BUILD_AVAILABILITY = '''
+    wget --quiet --spider "https://ci.modcluster.io/view/Mandrel/job/${MANDREL_BUILD}/JDK_VERSION=${JDK_VERSION},JDK_RELEASE=${JDK_RELEASE},LABEL=${LABEL}/${MANDREL_BUILD_NUMBER}/artifact/*zip*/archive.zip"
+    '''
+
     static final String LINUX_PREPARE_MANDREL = '''
     # Prepare Mandrel
     wget --quiet "https://ci.modcluster.io/view/Mandrel/job/${MANDREL_BUILD}/JDK_VERSION=${JDK_VERSION},JDK_RELEASE=${JDK_RELEASE},LABEL=${LABEL}/${MANDREL_BUILD_NUMBER}/artifact/*zip*/archive.zip"
@@ -136,6 +140,14 @@ class Constants {
         -Dquarkus.native.builder-image="${BUILDER_IMAGE}" \\
         -Dquarkus.native.container-runtime=${CONTAINER_RUNTIME} \\
         -Dquarkus.native.native-image-xmx=6g
+    '''
+
+    static final String WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY = '''
+    $url = 'https://ci.modcluster.io/view/Mandrel/job/%MANDREL_BUILD%/JDK_VERSION=%JDK_VERSION%,JDK_RELEASE=%JDK_RELEASE%,LABEL=%LABEL%/%MANDREL_BUILD_NUMBER%/artifact/*zip*/archive.zip';
+    $statusCode = (Invoke-WebRequest "https://ci.modcluster.io/view/Mandrel/job/${MANDREL_BUILD}/JDK_VERSION=${JDK_VERSION},JDK_RELEASE=${JDK_RELEASE},LABEL=${LABEL}/${MANDREL_BUILD_NUMBER}/artifact/*zip*/archive.zip" -DisableKeepAlive -UseBasicParsing -Method head -SkipHttpErrorCheck).StatusCode
+    if ( $statusCode -ne 200 ) {
+        exit 1
+    }
     '''
 
     static final String WINDOWS_PREPARE_MANDREL = '''

--- a/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
@@ -42,9 +42,19 @@ matrixJob('mandrel-22-3-windows-quarkus-tests') {
         )
     }
     steps {
-        batchFile {
-            command(Constants.WINDOWS_QUARKUS_TESTS)
-            unstableReturn(1)
+        conditionalSteps {
+            condition {
+                shell {
+                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
+            }
+            runner('DontRun')
+            steps {
+                batchFile {
+                    command(Constants.WINDOWS_QUARKUS_TESTS)
+                    unstableReturn(1)
+                }
+            }
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
@@ -61,11 +61,21 @@ matrixJob('mandrel-linux-integration-tests') {
         }
     }
     steps {
-        shell('echo DESCRIPTION_STRING=Q:${QUARKUS_VERSION},M:${MANDREL_BUILD},J:${JDK_VERSION}-${JDK_RELEASE}')
-        buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
-        shell {
-            command(Constants.LINUX_INTEGRATION_TESTS)
-            unstableReturn(1)
+        conditionalSteps {
+            condition {
+                shell {
+                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
+            }
+            runner('DontRun')
+            steps {
+                shell('echo DESCRIPTION_STRING=Q:${QUARKUS_VERSION},M:${MANDREL_BUILD},J:${JDK_VERSION}-${JDK_RELEASE}')
+                buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
+                shell {
+                    command(Constants.LINUX_INTEGRATION_TESTS)
+                    unstableReturn(1)
+                }
+            }
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
@@ -46,9 +46,19 @@ matrixJob('mandrel-linux-quarkus-subset-tests') {
         )
     }
     steps {
-        shell {
-            command(Constants.LINUX_QUARKUS_TESTS)
-            unstableReturn(1)
+        conditionalSteps {
+            condition {
+                shell {
+                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
+            }
+            runner('DontRun')
+            steps {
+                shell {
+                    command(Constants.LINUX_QUARKUS_TESTS)
+                    unstableReturn(1)
+                }
+            }
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
@@ -44,9 +44,19 @@ matrixJob('mandrel-linux-quarkus-tests') {
         )
     }
     steps {
-        shell {
-            command(Constants.LINUX_QUARKUS_TESTS)
-            unstableReturn(1)
+        conditionalSteps {
+            condition {
+                shell {
+                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
+            }
+            runner('DontRun')
+            steps {
+                shell {
+                    command(Constants.LINUX_QUARKUS_TESTS)
+                    unstableReturn(1)
+                }
+            }
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
@@ -61,11 +61,21 @@ matrixJob('mandrel-windows-integration-tests') {
         }
     }
     steps {
-        batchFile('echo DESCRIPTION_STRING=Q:%QUARKUS_VERSION%,M:%MANDREL_BUILD%,J:%JDK_VERSION%-%JDK_RELEASE%')
-        buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
-        batchFile {
-            command(Constants.WINDOWS_INTEGRATION_TESTS)
-            unstableReturn(1)
+        conditionalSteps {
+            condition {
+                shell {
+                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
+            }
+            runner('DontRun')
+            steps {
+                batchFile('echo DESCRIPTION_STRING=Q:%QUARKUS_VERSION%,M:%MANDREL_BUILD%,J:%JDK_VERSION%-%JDK_RELEASE%')
+                buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
+                batchFile {
+                    command(Constants.WINDOWS_INTEGRATION_TESTS)
+                    unstableReturn(1)
+                }
+            }
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
@@ -44,9 +44,19 @@ matrixJob('mandrel-windows-quarkus-tests') {
         )
     }
     steps {
-        batchFile {
-            command(Constants.WINDOWS_QUARKUS_TESTS)
-            unstableReturn(1)
+        conditionalSteps {
+            condition {
+                shell {
+                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
+            }
+            runner('DontRun')
+            steps {
+                batchFile {
+                    command(Constants.WINDOWS_QUARKUS_TESTS)
+                    unstableReturn(1)
+                }
+            }
         }
     }
     publishers {


### PR DESCRIPTION
When starting a test job manually for a specific MANDREL_BUILD the tests appear to fail in combinations for which the corresponding MANDREL_BUILD doesn't exist. With this change we perform a test and if the build doesn't exist we don't run the job.