### PR TITLE
Revert conditionalSteps and introduce combinations filter parameter

### DIFF
--- a/jenkins/jobs/builds/mandrel_21_3_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_21_3_linux_build_matrix.groovy
@@ -51,6 +51,7 @@ matrixJob('mandrel-21-3-linux-build-matrix') {
                 '21.3-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_21_3_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_21_3_windows_build_matrix.groovy
@@ -51,6 +51,7 @@ matrixJob('mandrel-21-3-windows-build-matrix') {
                 '21.3-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_22_1_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_22_1_linux_build_matrix.groovy
@@ -52,6 +52,7 @@ matrixJob('mandrel-22-1-linux-build-matrix') {
                 '22.1-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_22_1_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_22_1_windows_build_matrix.groovy
@@ -52,6 +52,7 @@ matrixJob('mandrel-22-1-windows-build-matrix') {
                 '22.1-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_22_2_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_22_2_linux_build_matrix.groovy
@@ -54,6 +54,7 @@ matrixJob('mandrel-22-2-linux-build-matrix') {
                 '22.2-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_22_2_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_22_2_windows_build_matrix.groovy
@@ -54,6 +54,7 @@ matrixJob('mandrel-22-2-windows-build-matrix') {
                 '22.2-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_22_3_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_22_3_linux_build_matrix.groovy
@@ -53,6 +53,7 @@ matrixJob('mandrel-22-3-linux-build-matrix') {
                 '22.3-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_22_3_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_22_3_windows_build_matrix.groovy
@@ -53,6 +53,7 @@ matrixJob('mandrel-22-3-windows-build-matrix') {
                 '22.3-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_graal_vm_21_3_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_graal_vm_21_3_linux_build_matrix.groovy
@@ -54,6 +54,7 @@ matrixJob('mandrel-graal-vm-21-3-linux-build-matrix') {
                 '21.3-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_graal_vm_21_3_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_graal_vm_21_3_windows_build_matrix.groovy
@@ -54,6 +54,7 @@ matrixJob('mandrel-graal-vm-21-3-windows-build-matrix') {
                 '21.3-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_graal_vm_22_1_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_graal_vm_22_1_linux_build_matrix.groovy
@@ -54,6 +54,7 @@ matrixJob('mandrel-graal-vm-22-1-linux-build-matrix') {
                 '22.1-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_graal_vm_22_1_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_graal_vm_22_1_windows_build_matrix.groovy
@@ -54,6 +54,7 @@ matrixJob('mandrel-graal-vm-22-1-windows-build-matrix') {
                 '22.1-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_master_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_master_linux_build_matrix.groovy
@@ -51,6 +51,7 @@ matrixJob('mandrel-master-linux-build-matrix') {
                 'master-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/builds/mandrel_master_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_master_windows_build_matrix.groovy
@@ -51,6 +51,7 @@ matrixJob('mandrel-master-windows-build-matrix') {
                 'master-SNAPSHOT',
                 'It must not contain spaces as it is used in tarball name too.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     multiscm {
         git {

--- a/jenkins/jobs/tests/Constants.groovy
+++ b/jenkins/jobs/tests/Constants.groovy
@@ -42,10 +42,6 @@ class Constants {
             'bouncycastle-jsse,' +
             'bouncycastle'
 
-    static final String LINUX_CHECK_MANDREL_BUILD_AVAILABILITY = '''
-    wget --quiet --spider "https://ci.modcluster.io/view/Mandrel/job/${MANDREL_BUILD}/JDK_VERSION=${JDK_VERSION},JDK_RELEASE=${JDK_RELEASE},LABEL=${LABEL}/${MANDREL_BUILD_NUMBER}/artifact/*zip*/archive.zip"
-    '''
-
     static final String LINUX_PREPARE_MANDREL = '''
     # Prepare Mandrel
     wget --quiet "https://ci.modcluster.io/view/Mandrel/job/${MANDREL_BUILD}/JDK_VERSION=${JDK_VERSION},JDK_RELEASE=${JDK_RELEASE},LABEL=${LABEL}/${MANDREL_BUILD_NUMBER}/artifact/*zip*/archive.zip"
@@ -146,14 +142,6 @@ class Constants {
         -Dquarkus.native.builder-image="${BUILDER_IMAGE}" \\
         -Dquarkus.native.container-runtime=${CONTAINER_RUNTIME} \\
         -Dquarkus.native.native-image-xmx=6g
-    '''
-
-    static final String WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY = '''
-    $url = 'https://ci.modcluster.io/view/Mandrel/job/%MANDREL_BUILD%/JDK_VERSION=%JDK_VERSION%,JDK_RELEASE=%JDK_RELEASE%,LABEL=%LABEL%/%MANDREL_BUILD_NUMBER%/artifact/*zip*/archive.zip';
-    $statusCode = (Invoke-WebRequest "https://ci.modcluster.io/view/Mandrel/job/${MANDREL_BUILD}/JDK_VERSION=${JDK_VERSION},JDK_RELEASE=${JDK_RELEASE},LABEL=${LABEL}/${MANDREL_BUILD_NUMBER}/artifact/*zip*/archive.zip" -DisableKeepAlive -UseBasicParsing -Method head -SkipHttpErrorCheck).StatusCode
-    if ( $statusCode -ne 200 ) {
-        exit 1
-    }
     '''
 
     static final String WINDOWS_PREPARE_MANDREL = '''

--- a/jenkins/jobs/tests/Constants.groovy
+++ b/jenkins/jobs/tests/Constants.groovy
@@ -149,14 +149,11 @@ class Constants {
     '''
 
     static final String WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY = '''
-    set checkCommand= ^
-        $url = 'https://ci.modcluster.io/view/Mandrel/job/%MANDREL_BUILD%/JDK_VERSION=%JDK_VERSION%,JDK_RELEASE=%JDK_RELEASE%,LABEL=%LABEL%/%MANDREL_BUILD_NUMBER%/artifact/*zip*/archive.zip'; ^
-        $statusCode = (Invoke-WebRequest "https://ci.modcluster.io/view/Mandrel/job/${MANDREL_BUILD}/JDK_VERSION=${JDK_VERSION},JDK_RELEASE=${JDK_RELEASE},LABEL=${LABEL}/${MANDREL_BUILD_NUMBER}/artifact/*zip*/archive.zip" -DisableKeepAlive -UseBasicParsing -Method head -SkipHttpErrorCheck).StatusCode ^
-        if ( $statusCode -eq 200 ) { ^
-            New-Item -Path '200.txt' -ItemType File ^
-        }
-    powershell -Command "%checkCommand%"
-    if not exist 200.txt exit 1
+    $url = 'https://ci.modcluster.io/view/Mandrel/job/%MANDREL_BUILD%/JDK_VERSION=%JDK_VERSION%,JDK_RELEASE=%JDK_RELEASE%,LABEL=%LABEL%/%MANDREL_BUILD_NUMBER%/artifact/*zip*/archive.zip';
+    $statusCode = (Invoke-WebRequest "https://ci.modcluster.io/view/Mandrel/job/${MANDREL_BUILD}/JDK_VERSION=${JDK_VERSION},JDK_RELEASE=${JDK_RELEASE},LABEL=${LABEL}/${MANDREL_BUILD_NUMBER}/artifact/*zip*/archive.zip" -DisableKeepAlive -UseBasicParsing -Method head -SkipHttpErrorCheck).StatusCode
+    if ( $statusCode -ne 200 ) {
+        exit 1
+    }
     '''
 
     static final String WINDOWS_PREPARE_MANDREL = '''

--- a/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
@@ -44,7 +44,9 @@ matrixJob('mandrel-22-3-windows-quarkus-tests') {
     steps {
         conditionalSteps {
             condition {
-                batch(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                shell {
+                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
             }
             runner('DontRun')
             steps {

--- a/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
@@ -42,19 +42,9 @@ matrixJob('mandrel-22-3-windows-quarkus-tests') {
         )
     }
     steps {
-        conditionalSteps {
-            condition {
-                shell {
-                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
-                }
-            }
-            runner('DontRun')
-            steps {
-                batchFile {
-                    command(Constants.WINDOWS_QUARKUS_TESTS)
-                    unstableReturn(1)
-                }
-            }
+        batchFile {
+            command(Constants.WINDOWS_QUARKUS_TESTS)
+            unstableReturn(1)
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_22_3_windows_quarkus_tests.groovy
@@ -40,6 +40,7 @@ matrixJob('mandrel-22-3-windows-quarkus-tests') {
                 'lastSuccessfulBuild',
                 'Pick a build number from MANDREL_BUILD or leave the default latest.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     steps {
         batchFile {

--- a/jenkins/jobs/tests/mandrel_linux_container_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_container_integration_tests.groovy
@@ -37,6 +37,7 @@ matrixJob('mandrel-linux-container-integration-tests') {
                 'Choose "heads" if you want to build from a branch, or "tags" if you want to build from a tag.'
         )
         stringParam('MANDREL_INTEGRATION_TESTS_REF', 'master', 'Branch or tag.')
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     scm {
         git {

--- a/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
@@ -51,6 +51,7 @@ matrixJob('mandrel-linux-integration-tests') {
                 'Choose "heads" if you want to build from a branch, or "tags" if you want to build from a tag.'
         )
         stringParam('MANDREL_INTEGRATION_TESTS_REF', 'master', 'Branch or tag.')
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     scm {
         git {

--- a/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
@@ -63,7 +63,9 @@ matrixJob('mandrel-linux-integration-tests') {
     steps {
         conditionalSteps {
             condition {
-                shell(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                shell {
+                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
             }
             runner('DontRun')
             steps {

--- a/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
@@ -61,21 +61,11 @@ matrixJob('mandrel-linux-integration-tests') {
         }
     }
     steps {
-        conditionalSteps {
-            condition {
-                shell {
-                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
-                }
-            }
-            runner('DontRun')
-            steps {
-                shell('echo DESCRIPTION_STRING=Q:${QUARKUS_VERSION},M:${MANDREL_BUILD},J:${JDK_VERSION}-${JDK_RELEASE}')
-                buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
-                shell {
-                    command(Constants.LINUX_INTEGRATION_TESTS)
-                    unstableReturn(1)
-                }
-            }
+        shell('echo DESCRIPTION_STRING=Q:${QUARKUS_VERSION},M:${MANDREL_BUILD},J:${JDK_VERSION}-${JDK_RELEASE}')
+        buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
+        shell {
+            command(Constants.LINUX_INTEGRATION_TESTS)
+            unstableReturn(1)
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_container_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_container_tests.groovy
@@ -28,6 +28,7 @@ matrixJob('mandrel-linux-quarkus-container-tests') {
         stringParam('CONTAINER_RUNTIME', 'podman', 'Command used, either "docker" or "podman". Note that podman is not installed on all executors...')
         stringParam('QUARKUS_REPO', 'https://github.com/quarkusio/quarkus.git', 'Quarkus repository.')
         stringParam('QUARKUS_MODULES', Constants.QUARKUS_MODULES_TESTS)
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     triggers {
         cron {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
@@ -44,6 +44,7 @@ matrixJob('mandrel-linux-quarkus-subset-tests') {
                 'lastSuccessfulBuild',
                 'Pick a build number from MANDREL_BUILD or leave the default latest.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     steps {
         shell {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
@@ -46,19 +46,9 @@ matrixJob('mandrel-linux-quarkus-subset-tests') {
         )
     }
     steps {
-        conditionalSteps {
-            condition {
-                shell {
-                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
-                }
-            }
-            runner('DontRun')
-            steps {
-                shell {
-                    command(Constants.LINUX_QUARKUS_TESTS)
-                    unstableReturn(1)
-                }
-            }
+        shell {
+            command(Constants.LINUX_QUARKUS_TESTS)
+            unstableReturn(1)
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_subset_tests.groovy
@@ -48,7 +48,9 @@ matrixJob('mandrel-linux-quarkus-subset-tests') {
     steps {
         conditionalSteps {
             condition {
-                shell(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                shell {
+                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
             }
             runner('DontRun')
             steps {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
@@ -42,6 +42,7 @@ matrixJob('mandrel-linux-quarkus-tests') {
                 'lastSuccessfulBuild',
                 'Pick a build number from MANDREL_BUILD or leave the default latest.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     steps {
         shell {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
@@ -44,19 +44,9 @@ matrixJob('mandrel-linux-quarkus-tests') {
         )
     }
     steps {
-        conditionalSteps {
-            condition {
-                shell {
-                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
-                }
-            }
-            runner('DontRun')
-            steps {
-                shell {
-                    command(Constants.LINUX_QUARKUS_TESTS)
-                    unstableReturn(1)
-                }
-            }
+        shell {
+            command(Constants.LINUX_QUARKUS_TESTS)
+            unstableReturn(1)
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_tests.groovy
@@ -46,7 +46,9 @@ matrixJob('mandrel-linux-quarkus-tests') {
     steps {
         conditionalSteps {
             condition {
-                shell(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                shell {
+                    command(Constants.LINUX_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
             }
             runner('DontRun')
             steps {

--- a/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
@@ -51,6 +51,7 @@ matrixJob('mandrel-windows-integration-tests') {
                 'Choose "heads" if you want to build from a branch, or "tags" if you want to build from a tag.'
         )
         stringParam('MANDREL_INTEGRATION_TESTS_REF', 'master', 'Branch or tag.')
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     scm {
         git {

--- a/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
@@ -61,21 +61,11 @@ matrixJob('mandrel-windows-integration-tests') {
         }
     }
     steps {
-        conditionalSteps {
-            condition {
-                shell {
-                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
-                }
-            }
-            runner('DontRun')
-            steps {
-                batchFile('echo DESCRIPTION_STRING=Q:%QUARKUS_VERSION%,M:%MANDREL_BUILD%,J:%JDK_VERSION%-%JDK_RELEASE%')
-                buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
-                batchFile {
-                    command(Constants.WINDOWS_INTEGRATION_TESTS)
-                    unstableReturn(1)
-                }
-            }
+        batchFile('echo DESCRIPTION_STRING=Q:%QUARKUS_VERSION%,M:%MANDREL_BUILD%,J:%JDK_VERSION%-%JDK_RELEASE%')
+        buildDescription(/DESCRIPTION_STRING=([^\s]*)/, '\\1')
+        batchFile {
+            command(Constants.WINDOWS_INTEGRATION_TESTS)
+            unstableReturn(1)
         }
     }
     publishers {

--- a/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
@@ -63,7 +63,9 @@ matrixJob('mandrel-windows-integration-tests') {
     steps {
         conditionalSteps {
             condition {
-                batch(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                shell {
+                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
             }
             runner('DontRun')
             steps {

--- a/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
@@ -42,6 +42,7 @@ matrixJob('mandrel-windows-quarkus-tests') {
                 'lastSuccessfulBuild',
                 'Pick a build number from MANDREL_BUILD or leave the default latest.'
         )
+        matrixCombinationsParam('MATRIX_COMBINATIONS_FILTER', "", 'Choose which combinations to run')
     }
     steps {
         batchFile {

--- a/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
@@ -46,7 +46,9 @@ matrixJob('mandrel-windows-quarkus-tests') {
     steps {
         conditionalSteps {
             condition {
-                batch(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                shell {
+                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
+                }
             }
             runner('DontRun')
             steps {

--- a/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_quarkus_tests.groovy
@@ -44,19 +44,9 @@ matrixJob('mandrel-windows-quarkus-tests') {
         )
     }
     steps {
-        conditionalSteps {
-            condition {
-                shell {
-                    command(Constants.WINDOWS_CHECK_MANDREL_BUILD_AVAILABILITY)
-                }
-            }
-            runner('DontRun')
-            steps {
-                batchFile {
-                    command(Constants.WINDOWS_QUARKUS_TESTS)
-                    unstableReturn(1)
-                }
-            }
+        batchFile {
+            command(Constants.WINDOWS_QUARKUS_TESTS)
+            unstableReturn(1)
         }
     }
     publishers {


### PR DESCRIPTION
It turns out conditionalSteps don't do exactly what I expected, i.e., they don't result in the job being skipped, but instead skip running the tests and mark the job as successful which is misleading (and requires us to accept empty junit reports and artifacts in the publishers).

As a result, I suggest we revert these changes and instead use the [Matrix Combinations Plugin](https://plugins.jenkins.io/matrix-combinations-parameter), which allows one to parameterize the [combinationFilter](https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.jobs.MatrixJob.combinationFilter) when running a job manually.

This results in the user being prompted with something like the following when building "with Parameters" (which also has more applications than just skipping jobs when a build number is not present for the combination):

![image](https://user-images.githubusercontent.com/1435395/200782546-18ee3fe4-970c-4c1f-a5e2-dae5303627da.png)