### PR TITLE
Phase out JDK11 builds and other Jenkins updates

### DIFF
--- a/jenkins/jobs/builds/mandrel_master_linux_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_master_linux_build_matrix.groovy
@@ -4,7 +4,6 @@ matrixJob('mandrel-master-linux-build-matrix') {
     axes {
         labelExpression('LABEL', ['el8_aarch64', 'el8'])
         text('JDK_VERSION',
-                '11',
                 '17'
         )
         text('JDK_RELEASE',

--- a/jenkins/jobs/builds/mandrel_master_windows_build_matrix.groovy
+++ b/jenkins/jobs/builds/mandrel_master_windows_build_matrix.groovy
@@ -4,7 +4,6 @@ matrixJob('mandrel-master-windows-build-matrix') {
     axes {
         labelExpression('LABEL', ['w2k19'])
         text('JDK_VERSION',
-                '11',
                 '17'
         )
         text('JDK_RELEASE',

--- a/jenkins/jobs/tests/mandrel_linux_container_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_container_integration_tests.groovy
@@ -7,7 +7,6 @@ matrixJob('mandrel-linux-container-integration-tests') {
                 'quay.io/quarkus/ubi-quarkus-mandrel:21.3-java17',
                 'quay.io/quarkus/ubi-quarkus-mandrel:22.2-java11',
                 'quay.io/quarkus/ubi-quarkus-mandrel:22.2-java17',
-                'quay.io/quarkus/ubi-quarkus-mandrel:22.3-java11',
                 'quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17'
         )
         text('QUARKUS_VERSION', Constants.QUARKUS_VERSION_RELEASED)

--- a/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_integration_tests.groovy
@@ -32,11 +32,7 @@ matrixJob('mandrel-linux-integration-tests') {
         }
     }
     combinationFilter(
-            '!(' +
-                    'QUARKUS_VERSION.startsWith("2.7") && (' +
-                    '   MANDREL_BUILD.contains("mandrel-master") || ' +
-                    '   MANDREL_BUILD.contains("mandrel-22")' +
-                    '))'
+            Constants.QUARKUS_VERSION_SHORT_COMBINATION_FILTER
     )
     parameters {
         stringParam(

--- a/jenkins/jobs/tests/mandrel_linux_quarkus_container_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_linux_quarkus_container_tests.groovy
@@ -5,7 +5,6 @@ matrixJob('mandrel-linux-quarkus-container-tests') {
         text('BUILDER_IMAGE',
                 'quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11',
                 'quay.io/quarkus/ubi-quarkus-mandrel:21.3-java17',
-                'quay.io/quarkus/ubi-quarkus-mandrel:22.3-java11',
                 'quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17'
         )
         text('QUARKUS_VERSION', Constants.QUARKUS_VERSION_BUILDER_IMAGE)

--- a/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
+++ b/jenkins/jobs/tests/mandrel_windows_integration_tests.groovy
@@ -32,11 +32,7 @@ matrixJob('mandrel-windows-integration-tests') {
         }
     }
     combinationFilter(
-            '!(' +
-                    'QUARKUS_VERSION.startsWith("2.7") && (' +
-                    '   MANDREL_BUILD.contains("mandrel-master") || ' +
-                    '   MANDREL_BUILD.contains("mandrel-22")' +
-                    '))'
+            Constants.QUARKUS_VERSION_SHORT_COMBINATION_FILTER
     )
     parameters {
         stringParam(


### PR DESCRIPTION
- Stop building master with Java 11
- There are no 22.3-java17 images
- Use the common combination filter in integration tests as well

Relates to https://github.com/graalvm/mandrel/issues/423
