### PR TITLE
Copy riscv64cpufeatures header file when present

### DIFF
--- a/build.java
+++ b/build.java
@@ -129,6 +129,11 @@ public class build
                 mandrelHome.resolve(Path.of("lib", "svm", "clibraries", PLATFORM, "include", "amd64cpufeatures.h")));
             FileSystem.copy(mandrelRepo.resolve(Path.of("substratevm", "src", "com.oracle.svm.native.libchelper", "include", "aarch64cpufeatures.h")),
                 mandrelHome.resolve(Path.of("lib", "svm", "clibraries", PLATFORM, "include", "aarch64cpufeatures.h")));
+            Path riscv64headers = mandrelRepo.resolve(Path.of("substratevm", "src", "com.oracle.svm.native.libchelper", "include", "riscv64cpufeatures.h"));
+            if (riscv64headers.toFile().exists())
+            {
+                FileSystem.copy(riscv64headers, mandrelHome.resolve(Path.of("lib", "svm", "clibraries", PLATFORM, "include", "riscv64cpufeatures.h")));
+            }
             FileSystem.copy(mandrelRepo.resolve(Path.of("substratevm", "src", "com.oracle.svm.libffi", "include", "svm_libffi.h")),
                 mandrelHome.resolve(Path.of("lib", "svm", "clibraries", PLATFORM, "include", "svm_libffi.h")));
             FileSystem.copy(mandrelRepo.resolve(Path.of("truffle", "src", "com.oracle.truffle.nfi.native", "include", "trufflenfi.h")),


### PR DESCRIPTION
Resolves build failures with latest graal due to:

```
> com.oracle.svm.core.util.VMError$HostedError: Header file include/riscv64cpufeatures.h not found at main search location(s):
```