### PR TITLE
Enable debug info generation for Mandrel 22.3 builds 

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -67,10 +67,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest openJDK11 with static libs
+    - name: Get latest openJDK17 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/11/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/11/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -80,12 +80,12 @@ jobs:
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java11-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java17-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java17-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java11-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java17-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -109,20 +109,20 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v1
       with:
-        name: mandrel-java11-linux-amd64-test-build
-        path: mandrel-java11-linux-amd64.tar.gz
+        name: mandrel-java17-linux-amd64-test-build
+        path: mandrel-java17-linux-amd64.tar.gz
     - name: Build Mandrel JDK with tarxz suffix
       run: |
         git -C ${MANDREL_REPO} checkout .
         ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tarxz --skip-clean --skip-java --skip-native
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
-        mv ${ARCHIVE_NAME} mandrel-java11-linux-amd64.tarxz
+        export ARCHIVE_NAME="mandrel-java17-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
+        mv ${ARCHIVE_NAME} mandrel-java17-linux-amd64.tarxz
     - name: Upload tarxz Mandrel build
       uses: actions/upload-artifact@v1
       with:
-        name: mandrel-java11-linux-amd64-test-build-tarxz
-        path: mandrel-java11-linux-amd64.tarxz
+        name: mandrel-java17-linux-amd64-test-build-tarxz
+        path: mandrel-java17-linux-amd64.tarxz
 
   build-and-test-on-windows:
     name: Windows Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -157,13 +157,13 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest openJDK11 with static libs
+    - name: Get latest openJDK17 with static libs
       run: |
         $wc = New-Object System.Net.WebClient
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/11/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/17/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
         Expand-Archive "$Env:temp\jdk.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/11/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/17/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
         Expand-Archive "$Env:temp\jdk-staticlibs.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*\lib\static" -Destination $Env:JAVA_HOME\lib\
         Remove-Item -Recurse "$Env:temp\jdk-*"
@@ -191,7 +191,7 @@ jobs:
           }
         }
         $MANDREL_VERSION_UNTIL_SPACE=$Env:MANDREL_VERSION -replace "^(.*?) .*$","`$1"
-        $MANDREL_HOME=".\mandrel-java11-$MANDREL_VERSION_UNTIL_SPACE"
+        $MANDREL_HOME=".\mandrel-java17-$MANDREL_VERSION_UNTIL_SPACE"
         $VERSION=(& $MANDREL_HOME\bin\native-image.cmd --version)
         Write-Host $VERSION
         if ("$VERSION" -NotMatch "$Env:MANDREL_VERSION") {
@@ -223,13 +223,13 @@ jobs:
       shell: bash
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java11-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
-        mv ${ARCHIVE_NAME} mandrel-java11-windows-amd64.zip
+        export ARCHIVE_NAME="mandrel-java17-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
+        mv ${ARCHIVE_NAME} mandrel-java17-windows-amd64.zip
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v1
       with:
-        name: mandrel-java11-windows-amd64-test-build
-        path: mandrel-java11-windows-amd64.zip
+        name: mandrel-java17-windows-amd64-test-build
+        path: mandrel-java17-windows-amd64.zip
 
   build-and-test-2-step:
     name: 2-step Linux Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -264,10 +264,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest openJDK11 with static libs
+    - name: Get latest openJDK17 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/11/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/11/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -298,12 +298,12 @@ jobs:
         --skip-java \
         --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java11-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java11-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java17-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java17-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java11-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java17-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -327,5 +327,5 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v1
       with:
-        name: mandrel-java11-linux-amd64-2step-test-build
-        path: mandrel-java11-linux-amd64.tar.gz
+        name: mandrel-java17-linux-amd64-2step-test-build
+        path: mandrel-java17-linux-amd64.tar.gz

--- a/build.java
+++ b/build.java
@@ -537,7 +537,7 @@ class SequentialBuild
     {
         final Tasks.Exec.Effects exec = new Tasks.Exec.Effects(task -> os.exec(task, false));
         final Tasks.FileReplace.Effects replace = Tasks.FileReplace.Effects.ofSystem();
-        LOG.debugf("Patch sources to remove dependency on truffle-api.jar ...");
+        LOG.debugf("Patch sources to remove dependency on truffle-api.jar and enable debug info generation...");
         final Path resourcesPath;
         if (options.mandrelPackagingHome == null)
         {
@@ -547,6 +547,7 @@ class SequentialBuild
         {
             resourcesPath = Path.of(options.mandrelPackagingHome, "resources");
         }
+        // NOTE: This patch also enables debug info generation by virtue of removing the has_component('svmee') condition
         exec.exec.accept(Tasks.Exec.of(List.of("git", "apply", resourcesPath.resolve("truffle-api-removal.patch").toString()), fs.mandrelRepo()));
         Mx.build(options, exec, replace, fs.mxHome(), fs.mandrelRepo(), os.javaHome());
         if (options.mavenDeploy && !options.skipJava)

--- a/build.java
+++ b/build.java
@@ -1,5 +1,4 @@
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
@@ -562,16 +561,8 @@ class SequentialBuild
                     LOG.debugf("Build Mandrel's wrapper jar...");
                     Mx.BuildArgs buildArgs = Mx.BuildArgs.of("--only", "MANDREL_PACKAGING_WRAPPER");
                     exec.exec.accept(Mx.mxbuild(options, fs.mxHome(), fs.mandrelRepo(), os.javaHome()).apply(buildArgs));
-                    // Add Specification-Version and Implementation-Version to jars' manifests.
-                    // These attributes are access by Red Hat Build of Quarkus to verify that the correct artifacts are being used.
-                    // The value of Specification-Version is not that important, but the Implementation-Version should match the version of the native-image.
                     LOG.debugf("Patch jars' manifests with Specification-Version and Implementation-Version...");
-                    File manifest = createTempManifest(options);
-                    mx.artifacts.forEach((artifact, paths) ->
-                    {
-                        final String jarPath = PathFinder.getFirstExisting(fs.mandrelRepo().resolve(paths[0]).toString(), artifact).toString();
-                        exec.exec.accept(Tasks.Exec.of(List.of("jar", "uvfm", jarPath, manifest.getPath()), fs.mandrelRepo()));
-                    });
+                    mx.artifacts.forEach(amendOrCreateManifest(options, replace));
                     LOG.debugf("Deploy maven artifacts...");
                     Mx.mavenDeploy(options, exec, fs.mxHome(), fs.mandrelRepo(), os.javaHome());
                 }
@@ -587,18 +578,48 @@ class SequentialBuild
         }
     }
 
-    private File createTempManifest(Options options) throws IOException
+    private BiConsumer<String, Path[]> amendOrCreateManifest(Options options, Tasks.FileReplace.Effects replace)
     {
-        File manifest = File.createTempFile("manifest", "mf");
-        manifest.deleteOnExit();
-        try (FileWriter manifestWriter = new FileWriter(manifest))
+        return (artifact, paths) ->
         {
-            manifestWriter.write("Specification-Version: 0.0\n");
-            manifestWriter.write("Implementation-Version: " + options.mavenVersion + "\n");
-            manifestWriter.flush();
-        }
-        return manifest;
+            final Path jarPath = PathFinder.getFirstExisting(fs.mandrelRepo().resolve(paths[0]).toString(), artifact);
+            try (java.nio.file.FileSystem jarfs = FileSystems.newFileSystem(jarPath, this.getClass().getClassLoader()))
+            {
+                Path metaInfPath = jarfs.getPath("/META-INF");
+                Path manifestPath = metaInfPath.resolve("MANIFEST.MF");
+                if (!Files.exists(manifestPath))
+                {
+                    if (!Files.exists(metaInfPath))
+                    {
+                        Files.createDirectory(metaInfPath);
+                    }
+                    Files.createFile(manifestPath);
+                }
+                Tasks.FileReplace.replace(new Tasks.FileReplace(manifestPath, amendManifest(options)), replace);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        };
     }
+
+    /*
+     * Add Specification-Version and Implementation-Version to jars' manifests.
+     * These attributes are accessed by Red Hat Build of Quarkus to verify that the correct artifacts are being used.
+     * The value of Specification-Version is not that important, but the Implementation-Version should match the version of the native-image.
+     */
+    private static Function<Stream<String>, List<String>> amendManifest(Options options)
+    {
+        return lines ->
+        {
+            List<String> result = lines.collect(Collectors.toList());
+            result.add("Specification-Version: 0.0");
+            result.add("Implementation-Version: " + options.mavenVersion);
+            return result;
+        };
+    }
+
 }
 
 class EnvVar

--- a/resources/truffle-api-removal.patch
+++ b/resources/truffle-api-removal.patch
@@ -2,6 +2,15 @@ diff --git a/sdk/mx.sdk/mx_sdk_vm_impl.py b/sdk/mx.sdk/mx_sdk_vm_impl.py
 index 43456a4778a..23763ed758b 100644
 --- a/sdk/mx.sdk/mx_sdk_vm_impl.py
 +++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
+@@ -1150,7 +1150,7 @@ def remove_lib_prefix_suffix(libname, require_suffix_prefix=True):
+ class SvmSupport(object):
+     def __init__(self):
+         self._svm_supported = has_component('svm', stage1=True)
+-        self._debug_supported = self._svm_supported and has_component('svmee', stage1=True) and not mx.is_darwin()  # GR-37542
++        self._debug_supported = self._svm_supported and not mx.is_darwin()  # GR-37542
+         self._pgo_supported = self._svm_supported and has_component('svmee', stage1=True)
+ 
+     def is_supported(self):
 @@ -1296,7 +1296,6 @@ class NativePropertiesBuildTask(mx.ProjectBuildTask):
              build_args = [
                  '--no-fallback',


### PR DESCRIPTION
The next feature release of GraalVM CE [will include debug info by default](https://github.com/oracle/graal/pull/5943).

This PR enables the generation of debug info by default for Mandrel 22.3 builds as well. 

Note that the debug info is embedded in the generated native libraries and it will be shipped with Mandrel.
