### PR TITLE
Set org.graalvm.version for Version.getCurrrent()

### DIFF
--- a/build.java
+++ b/build.java
@@ -310,6 +310,7 @@ public class build
                 logger.debugf("launcherMatcher.group(1): %s", launcherMatcher.group(1));
                 logger.debugf("launcherMatcher.group(2): %s", launcherMatcher.group(2));
                 final String launcherLine = launcherMatcher.group(1) +
+                    " -Dorg.graalvm.version=\"" + mandrelVersion + "\"" +
                     " -Dorg.graalvm.vendorversion=\"Mandrel-" + mandrelVersion + "\"" +
                     " -Dorg.graalvm.vendor=\"" + (vendor != null ? vendor : defaultVendor) + "\"" +
                     " -Dorg.graalvm.vendorurl=\"" + (vendorUrl != null ? vendorUrl : defaultVendorUrl ) + "\"" +


### PR DESCRIPTION
The GraalVM API Version.getCurrent() uses DefaultHomeFinder to get the version String in use and then uses Version.parse() to convert it to a Version object. With the change from #328 that got broken (as the org.graalvm.version) was erronously removed.