### PR TITLE
Libchelper is no longer jdk-specific on windows

### DIFF
--- a/build.java
+++ b/build.java
@@ -161,7 +161,7 @@ public class build
                 }
                 else
                 {
-                    libchelperSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.libchelper", ARCH, "libchelper.lib");
+                    libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.libchelper", ARCH, "libchelper.lib");
                     jvmlibSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.jvm.windows", ARCH, "jvm.lib");
                     reporterchelperSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.reporterchelper", ARCH, "reporterchelper.dll");
                 }


### PR DESCRIPTION
As of https://github.com/oracle/graal/pull/6713 libchelper is no longer jdk-specific on windows