### PR TITLE
Update and clean up to work with new Truffle refactoring

### DIFF
--- a/build.java
+++ b/build.java
@@ -871,8 +871,8 @@ class Mx
                 new Path[]{substrateDistPath.resolve("pointsto.jar"), Path.of("lib", "svm", "builder", "pointsto.jar")}),
             new SimpleEntry<>("org.graalvm.nativeimage:library-support.jar",
                 new Path[]{substrateDistPath.resolve("library-support.jar"), Path.of("lib", "svm", "library-support.jar")}),
-            new SimpleEntry<>("org.graalvm.truffle:truffle-api.jar",
-                new Path[]{truffleDistPath.resolve("truffle-api.jar"), Path.of("lib", "truffle", "truffle-api.jar")}),
+            new SimpleEntry<>("org.graalvm.truffle:truffle-compiler.jar",
+                new Path[]{truffleDistPath.resolve("truffle-compiler.jar"), Path.of("lib", "truffle", "truffle-compiler.jar")}),
             new SimpleEntry<>("org.graalvm.compiler:compiler.jar",
                 new Path[]{compilerDistPath.resolve("graal.jar"), Path.of("lib", "jvmci", "graal.jar")}),
             new SimpleEntry<>("org.graalvm.nativeimage:objectfile.jar",
@@ -903,7 +903,7 @@ class Mx
                 "NATIVE_IMAGE_BASE," +
                 "POINTSTO," +
                 "LIBRARY_SUPPORT," +
-                "TRUFFLE_API," +
+                "TRUFFLE_COMPILER," +
                 "GRAAL," +
                 "OBJECTFILE," +
                 "SVM_DRIVER," +
@@ -1109,18 +1109,19 @@ class Mx
         Map<String, String> dependenciesToPatch = Map.ofEntries(
             // Mandrel doesn't use truffle
             new SimpleEntry<>("^ +\"com.oracle.svm.truffle\",", ""),
+            new SimpleEntry<>("^ +\"truffle:TRUFFLE_API\",", ""),
+            new SimpleEntry<>("^ +\"truffle:TRUFFLE_RUNTIME\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.svm.truffle.api                   to org.graalvm.truffle\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.truffle.api.TruffleLanguage.Provider\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation.TruffleInstrument.Provider\",", ""),
+            new SimpleEntry<>("^ +\"com.oracle.truffle.api.provider.TruffleLanguageProvider\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation.provider.TruffleInstrumentProvider\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.svm.truffle.nfi\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.svm.truffle.nfi.posix\",", ""),
             new SimpleEntry<>("^ +\"com.oracle.svm.truffle.nfi.windows\",", ""),
-            // new SimpleEntry<>("^ +com.oracle.svm.truffle.tck\",", ""),
-            // new SimpleEntry<>("^ +\"truffle:TRUFFLE_API\"", ""), // Keep this as there are deps on it
             new SimpleEntry<>("^ +\"extracted-dependency:truffle:LIBFFI_DIST\"", ""),
-            new SimpleEntry<>("^ +\"extracted-dependency:truffle:TRUFFLE_NFI_GRAALVM_SUPPORT/include/trufflenfi.h\",", ""),
             new SimpleEntry<>("^ +\"file:src/com.oracle.svm.libffi/include/svm_libffi.h\",", ""),
+            new SimpleEntry<>("^ +\"extracted-dependency:truffle:TRUFFLE_NFI_GRAALVM_SUPPORT/include/trufflenfi.h\",", ""),
             // Mandrel doesn't use polyglot
             new SimpleEntry<>("^ +\"com.oracle.svm.polyglot\",", ""));
         Tasks.FileReplace.replace(
@@ -1139,28 +1140,7 @@ class Mx
         suitePy = Path.of("compiler", "mx.compiler", "suite.py");
         path = mandrelRepo.resolve(suitePy);
         dependenciesToPatch = Map.ofEntries(
-            // Mandrel doesn't use libgraal
-            new SimpleEntry<>("^ +\"org.graalvm.libgraal\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.libgraal.jni\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.libgraal                        to jdk.internal.vm.compiler.management\",", ""),
-            // Mandrel doesn't use truffle
-            // new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.amd64\",", ""), // Keep as it's needed by com.oracle.svm.core
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.serviceprovider\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot.java\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.hotspot.libgraal\",", ""),
-            // new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.hotspot.amd64\",", ""), // required by com.oracle.svm.core.meta.ObjectConstantEquality
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.hotspot.aarch64\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.jfr\",", ""),
-            // new SimpleEntry<>("^ +\"truffle:TRUFFLE_API\"", ""), // Keep this as there are deps on it
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.jfr            to jdk.internal.vm.compiler.truffle.jfr\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.impl.TruffleLocator\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.object.LayoutFactory\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.hotspot.TruffleCallBoundaryInstrumentationFactory\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.compiler.substitutions.GraphBuilderInvocationPluginProvider\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.LoopNodeFactory\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.TruffleTypes\",", ""),
-            new SimpleEntry<>("^ +\"org.graalvm.compiler.truffle.runtime.EngineCacheSupport\",", ""),
+            // Mandrel doesn't use llvm
             new SimpleEntry<>(",org.graalvm.nativeimage.llvm", ""));
         Tasks.FileReplace.replace(
             new Tasks.FileReplace(path, patchSuites(dependenciesToPatch))
@@ -1171,11 +1151,11 @@ class Mx
         path = mandrelRepo.resolve(suitePy);
         dependenciesToPatch = Map.of(
             // Mandrel doesn't use polyglot
-            // "^ +\"org.graalvm.polyglot\",", Keep as it's needed by TRUFFLE_API
+            "^ +\"org.graalvm.polyglot\",", "",
             "^ +\"org.graalvm.polyglot.proxy\",", "",
-            // "^ +\"org.graalvm.polyglot.io\",", Keep as it's needed by TRUFFLE_API
+            "^ +\"org.graalvm.polyglot.io\",", "",
             "^ +\"org.graalvm.polyglot.management\",", "",
-            // "^ +\"org.graalvm.polyglot.impl to org.graalvm.truffle\",", Keep as it's needed by TRUFFLE_API
+            "^ +\"org.graalvm.polyglot.impl to org.graalvm.truffle, com.oracle.truffle.enterprise\",", "",
             "^ +\"org.graalvm.polyglot.impl.AbstractPolyglotImpl\"", "",
             "^ +\"org.graalvm.polyglot to org.graalvm.truffle\"", "");
         Tasks.FileReplace.replace(
@@ -1183,35 +1163,9 @@ class Mx
             , effects
         );
 
-        suitePy = Path.of("truffle", "mx.truffle", "suite.py");
+        suitePy = Path.of("sdk", "mx.sdk", "mx_sdk_vm_impl.py");
         path = mandrelRepo.resolve(suitePy);
-        dependenciesToPatch = Map.ofEntries(
-            // Mandrel doesn't use the full TRUFFLE_API
-            new SimpleEntry<>("^ +\"com.oracle.truffle.object to jdk.internal.vm.compiler, com.oracle.graal.graal_enterprise\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.library to com.oracle.truffle.truffle_nfi_libffi, com.oracle.truffle.truffle_nfi\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation.TruffleInstrument.Provider\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.library.DefaultExportProvider\",", ""),
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.library.EagerExportProvider\",", " ),// Keep as it's needed by TRUFFLE_API
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.source\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.memory\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.io\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.frame\",", ""),
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.object\",", " ),// Keep as it brings com.oracle.truffle.api.interop
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation.provider\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.instrumentation.provider.TruffleInstrumentProvider\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.exception\",", ""), // alternative that brings com.oracle.truffle.api.interop
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.dsl\",", " ),// Keep as it's needed by com.oracle.truffle.api.library
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.profiles\",", " ),// Keep as it's needed by com.oracle.truffle.api.interop
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.interop\",", " ),// Keep as it brings com.oracle.truffle.api.library
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.debug\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.utilities\",", ""),
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.object\",", " ),// Keep as it brings com.oracle.truffle.api.object
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.object.dsl\",", ""), // alternative that brings com.oracle.truffle.api.object
-            new SimpleEntry<>("^ +\"com.oracle.truffle.polyglot\",", ""),
-            new SimpleEntry<>("^ +\"com.oracle.truffle.host\",", ""),
-            // new SimpleEntry<>("^ +\"com.oracle.truffle.api.library\",", " ),// Keep as it provides EagerExportProvider and is also needed by TRUFFLE_DSL_PROCESSOR which is needed by org.graalvm.compiler.truffle.options
-            new SimpleEntry<>("^ +\"com.oracle.truffle.api.staticobject\",", ""));
+        dependenciesToPatch = Map.of(" org.graalvm.truffle,", " ");
         Tasks.FileReplace.replace(
             new Tasks.FileReplace(path, patchSuites(dependenciesToPatch))
             , effects
@@ -1490,7 +1444,6 @@ class MxVersion implements Comparable<MxVersion>
  * Components reside in directories based on jdk compatibility, e.g.
  * ./substratevm/mxbuild/dists/jdk17/svm-agent.jar
  * ./substratevm/mxbuild/dists/jdk16/svm.jar
- * ./truffle/mxbuild/dists/jdk11/truffle-api.jar
  * ./truffle/mxbuild/dists/jdk9/truffle-dsl-processor.jar
  * <p>
  * It is not practical to hard code those, so this util class finds them.


### PR DESCRIPTION
See https://github.com/oracle/graal/pull/6986 for the refactoring that better splits Truffle dependencies

Closes: https://github.com/graalvm/mandrel/issues/531