### PR TITLE
Temporarily move to building 23.1

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/23.1]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/checkout@v3
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/23.1]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3
@@ -231,7 +231,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/23.1]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/checkout@v3
@@ -354,7 +354,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/23.1]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/checkout@v3

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -104,18 +104,6 @@ jobs:
         ${MANDREL_HOME}/bin/native-image HelloStrict
         ./hellostrict | tee native.txt
         diff java.txt native.txt
-        echo "
-        import org.graalvm.home.Version;
-        public class VersionTest {
-            private static final String VERSION = Version.getCurrent().toString();
-            public static void main(String[] args) {
-                System.out.println(VERSION);
-            }
-        }
-        " > VersionTest.java
-        ${MANDREL_HOME}/bin/javac -cp ${MANDREL_HOME}/lib/jvmci/graal-sdk.jar VersionTest.java
-        ${MANDREL_HOME}/bin/native-image --no-fallback --initialize-at-build-time=. --features=org.graalvm.home.HomeFinderFeature VersionTest
-        ./versiontest | grep "${MANDREL_VERSION}" || ( echo "got '$(./versiontest)' but expected '${MANDREL_VERSION}'" && exit 1 )
         ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
@@ -206,18 +194,6 @@ jobs:
           ${MANDREL_HOME}/bin/native-image HelloStrict
           ./hellostrict | tee native.txt
           diff java.txt native.txt
-          echo "
-          import org.graalvm.home.Version;
-          public class VersionTest {
-              private static final String VERSION = Version.getCurrent().toString();
-              public static void main(String[] args) {
-                  System.out.println(VERSION);
-              }
-          }
-          " > VersionTest.java
-          ${MANDREL_HOME}/bin/javac -cp ${MANDREL_HOME}/lib/jvmci/graal-sdk.jar VersionTest.java
-          ${MANDREL_HOME}/bin/native-image --no-fallback --initialize-at-build-time=. --features=org.graalvm.home.HomeFinderFeature VersionTest
-          ./versiontest | grep "${MANDREL_VERSION}" || ( echo "got '$(./versiontest)' but expected '${MANDREL_VERSION}'" && exit 1 )
           ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
       - name: Upload Mandrel build
         uses: actions/upload-artifact@v3
@@ -319,23 +295,7 @@ jobs:
           Write-Host $DIFF
           exit 1
         }
-        Set-Content -Path 'VersionTest.java' -Value "
-        import org.graalvm.home.Version;
-        public class VersionTest {
-            private static final String VERSION = Version.getCurrent().toString();
-            public static void main(String[] args) {
-                System.out.println(VERSION);
-            }
-        }
-        "
-        & $MANDREL_HOME\bin\javac -cp $MANDREL_HOME\lib\jvmci\graal-sdk.jar VersionTest.java
-        & $MANDREL_HOME\bin\native-image.cmd --no-fallback --initialize-at-build-time=. --features=org.graalvm.home.HomeFinderFeature VersionTest
-        $VERSION=(& ./versiontest)
-        if ("$VERSION" -NotMatch "$Env:MANDREL_VERSION") {
-          Write-Host got $VERSION but expected $Env:MANDREL_VERSION
-          exit 1
-        }
-        # $PREFIX && ${MANDREL_HOME}/bin/native-image.cmd --macro:native-image-launcher
+        & ${MANDREL_HOME}/bin/native-image.cmd --macro:native-image-launcher
     - name: Rename mandrel archive
       shell: bash
       run: |
@@ -439,18 +399,6 @@ jobs:
         ${MANDREL_HOME}/bin/native-image HelloStrict
         ./hellostrict | tee native.txt
         diff java.txt native.txt
-        echo "
-        import org.graalvm.home.Version;
-        public class VersionTest {
-            private static final String VERSION = Version.getCurrent().toString();
-            public static void main(String[] args) {
-                System.out.println(VERSION);
-            }
-        }
-        " > VersionTest.java
-        ${MANDREL_HOME}/bin/javac -cp ${MANDREL_HOME}/lib/jvmci/graal-sdk.jar VersionTest.java
-        ${MANDREL_HOME}/bin/native-image --no-fallback --initialize-at-build-time=. --features=org.graalvm.home.HomeFinderFeature VersionTest
-        ./versiontest | grep "${MANDREL_VERSION}" || ( echo "got '$(./versiontest)' but expected '${MANDREL_VERSION}'" && exit 1 )
         ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -105,6 +105,7 @@ jobs:
         ./hellostrict | tee native.txt
         diff java.txt native.txt
         ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
+        ${MANDREL_HOME}/bin/native-image --version
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
@@ -195,6 +196,7 @@ jobs:
           ./hellostrict | tee native.txt
           diff java.txt native.txt
           ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
+          ${MANDREL_HOME}/bin/native-image --version
       - name: Upload Mandrel build
         uses: actions/upload-artifact@v3
         with:
@@ -400,6 +402,7 @@ jobs:
         ./hellostrict | tee native.txt
         diff java.txt native.txt
         ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
+        ${MANDREL_HOME}/bin/native-image --version
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -66,10 +66,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest openJDK17 with static libs
+    - name: Get latest OpenJDK 21 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -79,12 +79,12 @@ jobs:
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java17-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java17-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java21-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java21-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java17-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java21-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -120,19 +120,19 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java17-linux-amd64-test-build
-        path: mandrel-java17-linux-amd64.tar.gz
+        name: mandrel-java21-linux-amd64-test-build
+        path: mandrel-java21-linux-amd64.tar.gz
     - name: Build Mandrel JDK with tarxz suffix
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tarxz --skip-clean --skip-java --skip-native
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java17-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
-        mv ${ARCHIVE_NAME} mandrel-java17-linux-amd64.tarxz
+        export ARCHIVE_NAME="mandrel-java21-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
+        mv ${ARCHIVE_NAME} mandrel-java21-linux-amd64.tarxz
     - name: Upload tarxz Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java17-linux-amd64-test-build-tarxz
-        path: mandrel-java17-linux-amd64.tarxz
+        name: mandrel-java21-linux-amd64-test-build-tarxz
+        path: mandrel-java21-linux-amd64.tarxz
 
   build-and-test-on-mac:
     name: MacOS Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -167,10 +167,10 @@ jobs:
           key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-      - name: Get latest openJDK17 with static libs
+      - name: Get latest OpenJDK 21 with static libs
         run: |
-          curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/mac/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-          curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/mac/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+          curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/mac/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+          curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/mac/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
           mkdir -p ${JAVA_HOME}
           tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
           tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -181,12 +181,12 @@ jobs:
           export JAVA_HOME=${MAC_JAVA_HOME}
           ${MAC_JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-          export ARCHIVE_NAME="mandrel-java17-darwin-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-          mv ${ARCHIVE_NAME} mandrel-java17-darwin-amd64.tar.gz
+          export ARCHIVE_NAME="mandrel-java21-darwin-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+          mv ${ARCHIVE_NAME} mandrel-java21-darwin-amd64.tar.gz
       - name: Smoke tests
         run: |
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-          export MANDREL_HOME=${PWD}/mandrel-java17-${MANDREL_VERSION_UNTIL_SPACE}/Contents/Home
+          export MANDREL_HOME=${PWD}/mandrel-java21-${MANDREL_VERSION_UNTIL_SPACE}/Contents/Home
           ${MANDREL_HOME}/bin/native-image --version
           ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
           echo "
@@ -222,8 +222,8 @@ jobs:
       - name: Upload Mandrel build
         uses: actions/upload-artifact@v3
         with:
-          name: mandrel-java17-darwin-amd64-test-build
-          path: mandrel-java17-darwin-amd64.tar.gz
+          name: mandrel-java21-darwin-amd64-test-build
+          path: mandrel-java21-darwin-amd64.tar.gz
 
   build-and-test-on-windows:
     name: Windows Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -258,13 +258,13 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest openJDK17 with static libs
+    - name: Get latest OpenJDK 21 with static libs
       run: |
         $wc = New-Object System.Net.WebClient
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/17/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/21/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
         Expand-Archive "$Env:temp\jdk.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/17/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/21/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
         Expand-Archive "$Env:temp\jdk-staticlibs.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*\lib\static" -Destination $Env:JAVA_HOME\lib\
         Remove-Item -Recurse "$Env:temp\jdk-*"
@@ -292,7 +292,7 @@ jobs:
           }
         }
         $MANDREL_VERSION_UNTIL_SPACE=$Env:MANDREL_VERSION -replace "^(.*?) .*$","`$1"
-        $MANDREL_HOME=".\mandrel-java17-$MANDREL_VERSION_UNTIL_SPACE"
+        $MANDREL_HOME=".\mandrel-java21-$MANDREL_VERSION_UNTIL_SPACE"
         $VERSION=(& $MANDREL_HOME\bin\native-image.cmd --version)
         Write-Host $VERSION
         if ("$VERSION" -NotMatch "$Env:MANDREL_VERSION") {
@@ -340,13 +340,13 @@ jobs:
       shell: bash
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java17-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
-        mv ${ARCHIVE_NAME} mandrel-java17-windows-amd64.zip
+        export ARCHIVE_NAME="mandrel-java21-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
+        mv ${ARCHIVE_NAME} mandrel-java21-windows-amd64.zip
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java17-windows-amd64-test-build
-        path: mandrel-java17-windows-amd64.zip
+        name: mandrel-java21-windows-amd64-test-build
+        path: mandrel-java21-windows-amd64.zip
 
   build-and-test-2-step:
     name: 2-step Linux Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -381,10 +381,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest openJDK17 with static libs
+    - name: Get latest OpenJDK 21 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/17/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -414,12 +414,12 @@ jobs:
         --skip-java \
         --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java17-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java17-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java21-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java21-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java17-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java21-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -455,5 +455,5 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java17-linux-amd64-2step-test-build
-        path: mandrel-java17-linux-amd64.tar.gz
+        name: mandrel-java21-linux-amd64-2step-test-build
+        path: mandrel-java21-linux-amd64.tar.gz


### PR DESCRIPTION
Graal `master` branch is currently not buildable (in the Mandrel config) and is, thus, not helpful for CI runs. In order to avoid breakages I propose to move to 23.1 temporarily.

This patch also does the following (in separate commits):

- Move to JDK 21 for building (23.1 is JDK 21 only)
- Disable the Version test which uses org.graalvm.home.Version and related classes now in `polyglot.jar` currently not part of Mandrel 23.1
- Also run `native-image --version` after the launcher macro build since we can catch bugs that way like https://github.com/graalvm/mandrel/issues/556