### PR TITLE
[CI] Move master build to JDK 22

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -66,10 +66,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 21 with static libs
+    - name: Get latest OpenJDK 22 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -79,12 +79,12 @@ jobs:
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java21-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java21-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java22-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java22-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java21-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java22-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -109,19 +109,19 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java21-linux-amd64-test-build
-        path: mandrel-java21-linux-amd64.tar.gz
+        name: mandrel-java22-linux-amd64-test-build
+        path: mandrel-java22-linux-amd64.tar.gz
     - name: Build Mandrel JDK with tarxz suffix
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tarxz --skip-clean --skip-java --skip-native
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java21-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
-        mv ${ARCHIVE_NAME} mandrel-java21-linux-amd64.tarxz
+        export ARCHIVE_NAME="mandrel-java22-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
+        mv ${ARCHIVE_NAME} mandrel-java22-linux-amd64.tarxz
     - name: Upload tarxz Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java21-linux-amd64-test-build-tarxz
-        path: mandrel-java21-linux-amd64.tarxz
+        name: mandrel-java22-linux-amd64-test-build-tarxz
+        path: mandrel-java22-linux-amd64.tarxz
 
   build-and-test-on-mac:
     name: MacOS Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -156,10 +156,10 @@ jobs:
           key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-      - name: Get latest OpenJDK 21 with static libs
+      - name: Get latest OpenJDK 22 with static libs
         run: |
-          curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/mac/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-          curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/mac/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+          curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/mac/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+          curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/mac/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
           mkdir -p ${JAVA_HOME}
           tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
           tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -170,12 +170,12 @@ jobs:
           export JAVA_HOME=${MAC_JAVA_HOME}
           ${MAC_JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-          export ARCHIVE_NAME="mandrel-java21-darwin-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-          mv ${ARCHIVE_NAME} mandrel-java21-darwin-amd64.tar.gz
+          export ARCHIVE_NAME="mandrel-java22-darwin-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+          mv ${ARCHIVE_NAME} mandrel-java22-darwin-amd64.tar.gz
       - name: Smoke tests
         run: |
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-          export MANDREL_HOME=${PWD}/mandrel-java21-${MANDREL_VERSION_UNTIL_SPACE}/Contents/Home
+          export MANDREL_HOME=${PWD}/mandrel-java22-${MANDREL_VERSION_UNTIL_SPACE}/Contents/Home
           ${MANDREL_HOME}/bin/native-image --version
           ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
           echo "
@@ -200,8 +200,8 @@ jobs:
       - name: Upload Mandrel build
         uses: actions/upload-artifact@v3
         with:
-          name: mandrel-java21-darwin-amd64-test-build
-          path: mandrel-java21-darwin-amd64.tar.gz
+          name: mandrel-java22-darwin-amd64-test-build
+          path: mandrel-java22-darwin-amd64.tar.gz
 
   build-and-test-on-windows:
     name: Windows Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -236,13 +236,13 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 21 with static libs
+    - name: Get latest OpenJDK 22 with static libs
       run: |
         $wc = New-Object System.Net.WebClient
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/21/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/22/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
         Expand-Archive "$Env:temp\jdk.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/21/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/22/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
         Expand-Archive "$Env:temp\jdk-staticlibs.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*\lib\static" -Destination $Env:JAVA_HOME\lib\
         Remove-Item -Recurse "$Env:temp\jdk-*"
@@ -270,7 +270,7 @@ jobs:
           }
         }
         $MANDREL_VERSION_UNTIL_SPACE=$Env:MANDREL_VERSION -replace "^(.*?) .*$","`$1"
-        $MANDREL_HOME=".\mandrel-java21-$MANDREL_VERSION_UNTIL_SPACE"
+        $MANDREL_HOME=".\mandrel-java22-$MANDREL_VERSION_UNTIL_SPACE"
         $VERSION=(& $MANDREL_HOME\bin\native-image.cmd --version)
         Write-Host $VERSION
         if ("$VERSION" -NotMatch "$Env:MANDREL_VERSION") {
@@ -302,13 +302,13 @@ jobs:
       shell: bash
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java21-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
-        mv ${ARCHIVE_NAME} mandrel-java21-windows-amd64.zip
+        export ARCHIVE_NAME="mandrel-java22-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
+        mv ${ARCHIVE_NAME} mandrel-java22-windows-amd64.zip
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java21-windows-amd64-test-build
-        path: mandrel-java21-windows-amd64.zip
+        name: mandrel-java22-windows-amd64-test-build
+        path: mandrel-java22-windows-amd64.zip
 
   build-and-test-2-step:
     name: 2-step Linux Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -343,10 +343,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 21 with static libs
+    - name: Get latest OpenJDK 22 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/21/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -376,12 +376,12 @@ jobs:
         --skip-java \
         --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java21-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java21-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java22-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java22-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java21-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java22-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -406,5 +406,5 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java21-linux-amd64-2step-test-build
-        path: mandrel-java21-linux-amd64.tar.gz
+        name: mandrel-java22-linux-amd64-2step-test-build
+        path: mandrel-java22-linux-amd64.tar.gz


### PR DESCRIPTION
JDK 21 build is broken due to:
https://github.com/graalvm/mandrel/issues/598