### PR TITLE
Add support for new build layout in 24.1

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -66,10 +66,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 22 with static libs
+    - name: Get latest OpenJDK 23 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -84,12 +84,12 @@ jobs:
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java22-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java22-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java23-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java23-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java22-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java23-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -114,19 +114,19 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java22-linux-amd64-test-build
-        path: mandrel-java22-linux-amd64.tar.gz
+        name: mandrel-java23-linux-amd64-test-build
+        path: mandrel-java23-linux-amd64.tar.gz
     - name: Build Mandrel JDK with tarxz suffix
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tarxz --skip-clean --skip-java --skip-native
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java22-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
-        mv ${ARCHIVE_NAME} mandrel-java22-linux-amd64.tarxz
+        export ARCHIVE_NAME="mandrel-java23-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
+        mv ${ARCHIVE_NAME} mandrel-java23-linux-amd64.tarxz
     - name: Upload tarxz Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java22-linux-amd64-test-build-tarxz
-        path: mandrel-java22-linux-amd64.tarxz
+        name: mandrel-java23-linux-amd64-test-build-tarxz
+        path: mandrel-java23-linux-amd64.tarxz
 
   build-and-test-on-mac:
     name: MacOS Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -161,10 +161,10 @@ jobs:
           key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-      - name: Get latest OpenJDK 22 with static libs
+      - name: Get latest OpenJDK 23 with static libs
         run: |
-          curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/mac/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-          curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/mac/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+          curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/mac/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+          curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/mac/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
           mkdir -p ${JAVA_HOME}
           tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
           tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -181,12 +181,12 @@ jobs:
           export JAVA_HOME=${MAC_JAVA_HOME}
           ${MAC_JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-          export ARCHIVE_NAME="mandrel-java22-darwin-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-          mv ${ARCHIVE_NAME} mandrel-java22-darwin-amd64.tar.gz
+          export ARCHIVE_NAME="mandrel-java23-darwin-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+          mv ${ARCHIVE_NAME} mandrel-java23-darwin-amd64.tar.gz
       - name: Smoke tests
         run: |
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-          export MANDREL_HOME=${PWD}/mandrel-java22-${MANDREL_VERSION_UNTIL_SPACE}/Contents/Home
+          export MANDREL_HOME=${PWD}/mandrel-java23-${MANDREL_VERSION_UNTIL_SPACE}/Contents/Home
           ${MANDREL_HOME}/bin/native-image --version
           ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
           echo "
@@ -211,8 +211,8 @@ jobs:
       - name: Upload Mandrel build
         uses: actions/upload-artifact@v3
         with:
-          name: mandrel-java22-darwin-amd64-test-build
-          path: mandrel-java22-darwin-amd64.tar.gz
+          name: mandrel-java23-darwin-amd64-test-build
+          path: mandrel-java23-darwin-amd64.tar.gz
 
   build-and-test-on-windows:
     name: Windows Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -247,13 +247,13 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 22 with static libs
+    - name: Get latest OpenJDK 23 with static libs
       run: |
         $wc = New-Object System.Net.WebClient
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/22/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/23/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
         Expand-Archive "$Env:temp\jdk.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/22/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/23/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
         Expand-Archive "$Env:temp\jdk-staticlibs.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*\lib\static" -Destination $Env:JAVA_HOME\lib\
         Remove-Item -Recurse "$Env:temp\jdk-*"
@@ -286,7 +286,7 @@ jobs:
           }
         }
         $MANDREL_VERSION_UNTIL_SPACE=$Env:MANDREL_VERSION -replace "^(.*?) .*$","`$1"
-        $MANDREL_HOME=".\mandrel-java22-$MANDREL_VERSION_UNTIL_SPACE"
+        $MANDREL_HOME=".\mandrel-java23-$MANDREL_VERSION_UNTIL_SPACE"
         $VERSION=(& $MANDREL_HOME\bin\native-image.cmd --version)
         Write-Host $VERSION
         if ("$VERSION" -NotMatch "$Env:MANDREL_VERSION") {
@@ -318,13 +318,13 @@ jobs:
       shell: bash
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java22-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
-        mv ${ARCHIVE_NAME} mandrel-java22-windows-amd64.zip
+        export ARCHIVE_NAME="mandrel-java23-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
+        mv ${ARCHIVE_NAME} mandrel-java23-windows-amd64.zip
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java22-windows-amd64-test-build
-        path: mandrel-java22-windows-amd64.zip
+        name: mandrel-java23-windows-amd64-test-build
+        path: mandrel-java23-windows-amd64.zip
 
   build-and-test-2-step:
     name: 2-step Linux Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -359,10 +359,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 22 with static libs
+    - name: Get latest OpenJDK 23 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/22/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -397,12 +397,12 @@ jobs:
         --skip-java \
         --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java22-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java22-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java23-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java23-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java22-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java23-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -427,5 +427,5 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java22-linux-amd64-2step-test-build
-        path: mandrel-java22-linux-amd64.tar.gz
+        name: mandrel-java23-linux-amd64-2step-test-build
+        path: mandrel-java23-linux-amd64.tar.gz

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -168,6 +168,12 @@ jobs:
           mkdir -p ${JAVA_HOME}
           tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
           tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+          # work-around for https://github.com/adoptium/temurin-build/issues/3602
+          pushd ${MAC_JAVA_HOME}
+          if [ -e lib/static/darwin-arm64 ]; then
+            mv lib/static/darwin-arm64 lib/static/darwin-amd64
+          fi
+          popd
           echo ${MAC_JAVA_HOME}
           ${MAC_JAVA_HOME}/bin/java --version
       - name: Use python 3.10

--- a/build.java
+++ b/build.java
@@ -173,21 +173,9 @@ public class build
             String platformAndJDK = PLATFORM + "-" + JDK_VERSION;
             if (IS_WINDOWS)
             {
-                Path libchelperSource;
-                Path jvmlibSource;
-                Path reporterchelperSource;
-                if (MxVersion.mx5_313_0.compareTo(mx.version) > 0)
-                {
-                    libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "src", "com.oracle.svm.native.libchelper", ARCH, "libchelper.lib");
-                    jvmlibSource = Path.of("substratevm", "mxbuild", PLATFORM, "src", "com.oracle.svm.native.jvm.windows", ARCH, "jvm.lib");
-                    reporterchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "src", "com.oracle.svm.native.reporterchelper", ARCH, "reporterchelper.dll");
-                }
-                else
-                {
-                    libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.libchelper", ARCH, "libchelper.lib");
-                    jvmlibSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.jvm.windows", ARCH, "jvm.lib");
-                    reporterchelperSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.reporterchelper", ARCH, "reporterchelper.dll");
-                }
+                Path libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.libchelper", PLATFORM, "default", "libchelper.lib");
+                Path jvmlibSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.jvm.windows", PLATFORM, "default", "jvm.lib");
+                Path reporterchelperSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.reporterchelper", PLATFORM, "default", "reporterchelper.dll");
                 FileSystem.copy(mandrelRepo.resolve(libchelperSource),
                     mandrelJavaHome.resolve(Path.of("lib", "svm", "clibraries", PLATFORM, "libchelper.lib")));
                 FileSystem.copy(mandrelRepo.resolve(jvmlibSource),
@@ -197,30 +185,14 @@ public class build
             }
             else
             {
-                Path libchelperSource;
-                Path libjvmSource;
                 Path libdarwinSource = null;
-                Path reporterchelperSource;
-                if (MxVersion.mx5_313_0.compareTo(mx.version) > 0)
-                {
-                    libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "src", "com.oracle.svm.native.libchelper", ARCH, "liblibchelper.a");
-                    libjvmSource = Path.of("substratevm", "mxbuild", PLATFORM, "src", "com.oracle.svm.native.jvm.posix", ARCH, "libjvm.a");
-                    if (IS_MAC)
-                    {
-                        libdarwinSource = Path.of("substratevm", "mxbuild", PLATFORM, "src", "com.oracle.svm.native.darwin", ARCH, "libdarwin.a");
-                    }
-                    reporterchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "src", "com.oracle.svm.native.reporterchelper", ARCH, System.mapLibraryName("reporterchelper"));
-                }
-                else
-                {
-                    libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.libchelper", ARCH, "liblibchelper.a");
-                    libjvmSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.jvm.posix", ARCH, "libjvm.a");
-                    if (IS_MAC)
-                    {
-                        libdarwinSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.darwin", ARCH, "libdarwin.a");
-                    }
-                    reporterchelperSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.reporterchelper", ARCH, System.mapLibraryName("reporterchelper"));
-                }
+		Path libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.libchelper", PLATFORM, "glibc", "liblibchelper.a");
+		Path libjvmSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.jvm.posix", PLATFORM, "glibc", "libjvm.a");
+		if (IS_MAC)
+		{
+		    libdarwinSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.darwin", ARCH, "libdarwin.a");
+		}
+		Path reporterchelperSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.reporterchelper", PLATFORM, "glibc", System.mapLibraryName("reporterchelper"));
                 FileSystem.copy(mandrelRepo.resolve(libchelperSource),
                     mandrelJavaHome.resolve(Path.of("lib", "svm", "clibraries", PLATFORM, "liblibchelper.a")));
                 FileSystem.copy(mandrelRepo.resolve(libjvmSource),

--- a/build.java
+++ b/build.java
@@ -186,13 +186,13 @@ public class build
             else
             {
                 Path libdarwinSource = null;
-		Path libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.libchelper", PLATFORM, "glibc", "liblibchelper.a");
-		Path libjvmSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.jvm.posix", PLATFORM, "glibc", "libjvm.a");
-		if (IS_MAC)
-		{
-		    libdarwinSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.darwin", ARCH, "libdarwin.a");
-		}
-		Path reporterchelperSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.reporterchelper", PLATFORM, "glibc", System.mapLibraryName("reporterchelper"));
+                Path libchelperSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.libchelper", PLATFORM, (IS_MAC ? "default" : "glibc"), "liblibchelper.a");
+                Path libjvmSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.jvm.posix", PLATFORM, (IS_MAC ? "default" : "glibc"), "libjvm.a");
+                if (IS_MAC)
+                {
+                    libdarwinSource = Path.of("substratevm", "mxbuild", PLATFORM, "com.oracle.svm.native.darwin", PLATFORM, "default", "libdarwin.a");
+                }
+                Path reporterchelperSource = Path.of("substratevm", "mxbuild", platformAndJDK, "com.oracle.svm.native.reporterchelper", PLATFORM, (IS_MAC ? "default" : "glibc"), System.mapLibraryName("reporterchelper"));
                 FileSystem.copy(mandrelRepo.resolve(libchelperSource),
                     mandrelJavaHome.resolve(Path.of("lib", "svm", "clibraries", PLATFORM, "liblibchelper.a")));
                 FileSystem.copy(mandrelRepo.resolve(libjvmSource),


### PR DESCRIPTION
The new location is, for example, `linux-amd64/glibc/liblibchelper.a` when it used to be `amd64/liblibchelper.a`.

This also removes an MX 5.313 conditional which is useless in master of mandrel-packaging which is supposed to build latest graal/master (needing mx 6+).

This fixes build issues seen in CI such as this one:
https://github.com/graalvm/mandrel/actions/runs/7442144672/job/20245208110#step:8:475