### PR TITLE
[23.0] Introduce `--disable-debuginfo-stripping` option

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -45,12 +45,11 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx
@@ -135,12 +134,12 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      shell: bash
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx
@@ -242,12 +241,11 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx

--- a/build.java
+++ b/build.java
@@ -389,6 +389,7 @@ class Options
     final String archiveSuffix;
     final String vendor;
     final String vendorUrl;
+    final boolean disableDebuginfoStripping;
 
     Options(
         boolean mavenDeploy
@@ -410,6 +411,7 @@ class Options
         , String archiveSuffix
         , String vendor
         , String vendorUrl
+        , boolean disableDebuginfoStripping
     )
     {
         this.mavenDeploy = mavenDeploy;
@@ -431,6 +433,7 @@ class Options
         this.archiveSuffix = archiveSuffix;
         this.vendor = vendor;
         this.vendorUrl = vendorUrl;
+        this.disableDebuginfoStripping = disableDebuginfoStripping;
     }
 
     public static Options from(Map<String, List<String>> args)
@@ -464,6 +467,7 @@ class Options
         final boolean skipJava = args.containsKey("skip-java");
         final boolean skipNative = args.containsKey("skip-native");
         final boolean skipNativeAgents = args.containsKey("skip-native-agents");
+        final boolean disableDebuginfoStripping = args.containsKey("disable-debuginfo-stripping");
 
         final String archiveSuffix = optional("archive-suffix", args);
 
@@ -487,6 +491,7 @@ class Options
             , archiveSuffix
             , vendor
             , vendorUrl
+            , disableDebuginfoStripping
         );
     }
 
@@ -1048,6 +1053,7 @@ class Mx
                     , "--native-images=lib:native-image-agent,lib:native-image-diagnostics-agent"
                     , "--components=ni"
                     , "--exclude-components=nju,svmnfi,svml,tflm"
+                    , options.disableDebuginfoStripping ? "--disable-debuginfo-stripping" : ""
                     , "build"
                 )
                 , buildArgs.args


### PR DESCRIPTION
Enables the use of `--disable-debuginfo-stripping` which was introduced
in https://github.com/oracle/graal/pull/7624
