### PR TITLE
Introduce `--disable-debuginfo-stripping` option

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -48,12 +48,11 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx
@@ -235,12 +234,12 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      shell: bash
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx
@@ -347,12 +346,11 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx

--- a/build.java
+++ b/build.java
@@ -448,6 +448,7 @@ class Options
     final String vendor;
     final String vendorUrl;
     final boolean deployLocally;
+    final boolean disableDebuginfoStripping;
 
     Options(
         boolean mavenDeploy
@@ -470,6 +471,7 @@ class Options
         , String vendor
         , String vendorUrl
         , boolean deployLocally
+        , boolean disableDebuginfoStripping
     )
     {
         this.mavenDeploy = mavenDeploy;
@@ -492,6 +494,7 @@ class Options
         this.vendor = vendor;
         this.vendorUrl = vendorUrl;
         this.deployLocally = deployLocally;
+        this.disableDebuginfoStripping = disableDebuginfoStripping;
     }
 
     public static Options from(Map<String, List<String>> args)
@@ -530,6 +533,7 @@ class Options
         final boolean skipJava = args.containsKey("skip-java");
         final boolean skipNative = args.containsKey("skip-native");
         final boolean skipNativeAgents = args.containsKey("skip-native-agents");
+        final boolean disableDebuginfoStripping = args.containsKey("disable-debuginfo-stripping");
 
         final String archiveSuffix = optional("archive-suffix", args);
 
@@ -554,6 +558,7 @@ class Options
             , vendor
             , vendorUrl
             , mavenDeployLocal
+            , disableDebuginfoStripping
         );
     }
 
@@ -1150,6 +1155,7 @@ class Mx
                     , "--native-images=lib:native-image-agent,lib:native-image-diagnostics-agent"
                     , "--components=ni"
                     , "--exclude-components=nju,svmnfi,svml,tflm"
+                    , options.disableDebuginfoStripping ? "--disable-debuginfo-stripping" : ""
                     , "build"
                 )
                 , buildArgs.args


### PR DESCRIPTION
Cherry picked commits from https://github.com/graalvm/mandrel-packaging/pull/387 to `master`

- Introduce `--disable-debuginfo-stripping` option
  
  Enables the use of `--disable-debuginfo-stripping` which was introduced
in https://github.com/oracle/graal/pull/7624

  (cherry picked from commit https://github.com/graalvm/mandrel-packaging/commit/ca631429f403c0e6cda1a44bff3775216de36db3)

- [CI] Fetch compatible mx version instead of `master`

  (cherry picked from commit https://github.com/graalvm/mandrel-packaging/commit/d4b0980841dd8c929105dd64e65d7175779deedf)