### PR TITLE
[23.1] Backport: Introduce --disable-debuginfo-stripping option

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -48,12 +48,11 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: 6.45.0
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx
@@ -218,12 +217,12 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: 6.45.0
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      shell: bash
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx
@@ -325,12 +324,11 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: 6.45.0
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -76,7 +76,7 @@ jobs:
         ${JAVA_HOME}/bin/java --version
     - name: Build Mandrel JDK
       run: |
-        ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
+        ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
         export ARCHIVE_NAME="mandrel-java21-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
         mv ${ARCHIVE_NAME} mandrel-java21-linux-amd64.tar.gz
@@ -167,7 +167,7 @@ jobs:
       - name: Build Mandrel JDK
         run: |
           export JAVA_HOME=${MAC_JAVA_HOME}
-          ${MAC_JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
+          ${MAC_JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
           export ARCHIVE_NAME="mandrel-java21-darwin-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
           mv ${ARCHIVE_NAME} mandrel-java21-darwin-amd64.tar.gz
@@ -255,7 +255,6 @@ jobs:
           }
         }
         & $Env:JAVA_HOME\bin\java -ea build.java `
-          --verbose `
           --mx-home $Env:MX_HOME `
           --mandrel-version $Env:MANDREL_VERSION `
           --mandrel-repo $Env:MANDREL_REPO `
@@ -354,7 +353,6 @@ jobs:
       run: |
         # Build the Java bits
         ${JAVA_HOME}/bin/java -ea build.java \
-        --verbose \
         --mx-home ${MX_HOME} \
         --mandrel-repo ${MANDREL_REPO} \
         --mandrel-version "${MANDREL_VERSION}" \
@@ -367,7 +365,6 @@ jobs:
         --mandrel-home temp-build
         # Build the native bits
         ./temp-build/bin/java -ea build.java \
-        --verbose \
         --mx-home ${MX_HOME} \
         --mandrel-repo ${MANDREL_REPO} \
         --mandrel-version "${MANDREL_VERSION}" \

--- a/build.java
+++ b/build.java
@@ -468,6 +468,7 @@ class Options
     final String vendor;
     final String vendorUrl;
     final boolean deployLocally;
+    final boolean disableDebuginfoStripping;
 
     Options(
         boolean mavenDeploy
@@ -490,6 +491,7 @@ class Options
         , String vendor
         , String vendorUrl
         , boolean deployLocally
+        , boolean disableDebuginfoStripping
     )
     {
         this.mavenDeploy = mavenDeploy;
@@ -512,6 +514,7 @@ class Options
         this.vendor = vendor;
         this.vendorUrl = vendorUrl;
         this.deployLocally = deployLocally;
+        this.disableDebuginfoStripping = disableDebuginfoStripping;
     }
 
     public static Options from(Map<String, List<String>> args)
@@ -550,6 +553,7 @@ class Options
         final boolean skipJava = args.containsKey("skip-java");
         final boolean skipNative = args.containsKey("skip-native");
         final boolean skipNativeAgents = args.containsKey("skip-native-agents");
+        final boolean disableDebuginfoStripping = args.containsKey("disable-debuginfo-stripping");
 
         final String archiveSuffix = optional("archive-suffix", args);
 
@@ -574,6 +578,7 @@ class Options
             , vendor
             , vendorUrl
             , mavenDeployLocal
+            , disableDebuginfoStripping
         );
     }
 
@@ -1170,6 +1175,7 @@ class Mx
                     , "--native-images=lib:native-image-agent,lib:native-image-diagnostics-agent"
                     , "--components=ni"
                     , "--exclude-components=nju,svmnfi,svml,tflm"
+                    , options.disableDebuginfoStripping ? "--disable-debuginfo-stripping" : ""
                     , "build"
                 )
                 , buildArgs.args


### PR DESCRIPTION
Cherry picked commits from https://github.com/graalvm/mandrel-packaging/pull/388 to `23.1`

- Introduce `--disable-debuginfo-stripping` option
- [CI] Fetch compatible mx version instead of `master`
- [CI] Disable `--verbose` in CI runs, because it adds too much noise
