### PR TITLE
[24.0] Backport: Introduce --disable-debuginfo-stripping option

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -48,12 +48,11 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx
@@ -143,12 +142,11 @@ jobs:
           fetch-depth: 1
           ref: ${{ matrix.mandrel-ref }}
           path: ${{ github.workspace }}/mandrel
-      - uses: actions/checkout@v3
-        with:
-          repository: graalvm/mx.git
-          fetch-depth: 1
-          ref: master
-          path: ${{ github.workspace }}/mx
+      - name: Checkout MX
+        run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
       - uses: actions/cache@v3
         with:
           path: ~/.mx
@@ -229,12 +227,12 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      shell: bash
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx
@@ -341,12 +339,11 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.mandrel-ref }}
         path: ${{ github.workspace }}/mandrel
-    - uses: actions/checkout@v3
-      with:
-        repository: graalvm/mx.git
-        fetch-depth: 1
-        ref: master
-        path: ${{ github.workspace }}/mx
+    - name: Checkout MX
+      run: |
+          VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
+          git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_HOME}
+          ./mx/mx --version
     - uses: actions/cache@v3
       with:
         path: ~/.mx

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -81,7 +81,7 @@ jobs:
         python-version: '3.10'
     - name: Build Mandrel JDK
       run: |
-        ${JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
+        ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
         export ARCHIVE_NAME="mandrel-java22-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
         mv ${ARCHIVE_NAME} mandrel-java22-linux-amd64.tar.gz
@@ -177,7 +177,7 @@ jobs:
       - name: Build Mandrel JDK
         run: |
           export JAVA_HOME=${MAC_JAVA_HOME}
-          ${MAC_JAVA_HOME}/bin/java -ea build.java --verbose --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
+          ${MAC_JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
           export ARCHIVE_NAME="mandrel-java22-darwin-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
           mv ${ARCHIVE_NAME} mandrel-java22-darwin-amd64.tar.gz
@@ -270,7 +270,6 @@ jobs:
           }
         }
         & $Env:JAVA_HOME\bin\java -ea build.java `
-          --verbose `
           --mx-home $Env:MX_HOME `
           --mandrel-version $Env:MANDREL_VERSION `
           --mandrel-repo $Env:MANDREL_REPO `
@@ -374,7 +373,6 @@ jobs:
       run: |
         # Build the Java bits
         ${JAVA_HOME}/bin/java -ea build.java \
-        --verbose \
         --mx-home ${MX_HOME} \
         --mandrel-repo ${MANDREL_REPO} \
         --mandrel-version "${MANDREL_VERSION}" \
@@ -387,7 +385,6 @@ jobs:
         --mandrel-home temp-build
         # Build the native bits
         ./temp-build/bin/java -ea build.java \
-        --verbose \
         --mx-home ${MX_HOME} \
         --mandrel-repo ${MANDREL_REPO} \
         --mandrel-version "${MANDREL_VERSION}" \

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/24.0]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/24.0]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3
@@ -218,7 +218,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/24.0]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/checkout@v3
@@ -329,7 +329,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-ref: [graal/master]
+        mandrel-ref: [mandrel/24.0]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/checkout@v3

--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -166,6 +166,12 @@ jobs:
           mkdir -p ${JAVA_HOME}
           tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
           tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+          # work-around for https://github.com/adoptium/temurin-build/issues/3602
+          pushd ${MAC_JAVA_HOME}
+          if [ -e lib/static/darwin-arm64 ]; then
+            mv lib/static/darwin-arm64 lib/static/darwin-amd64
+          fi
+          popd
           echo ${MAC_JAVA_HOME}
           ${MAC_JAVA_HOME}/bin/java --version
       - name: Use python 3.10

--- a/build.java
+++ b/build.java
@@ -474,6 +474,7 @@ class Options
     final String vendor;
     final String vendorUrl;
     final boolean deployLocally;
+    final boolean disableDebuginfoStripping;
 
     Options(
         boolean mavenDeploy
@@ -496,6 +497,7 @@ class Options
         , String vendor
         , String vendorUrl
         , boolean deployLocally
+        , boolean disableDebuginfoStripping
     )
     {
         this.mavenDeploy = mavenDeploy;
@@ -518,6 +520,7 @@ class Options
         this.vendor = vendor;
         this.vendorUrl = vendorUrl;
         this.deployLocally = deployLocally;
+        this.disableDebuginfoStripping = disableDebuginfoStripping;
     }
 
     public static Options from(Map<String, List<String>> args)
@@ -556,6 +559,7 @@ class Options
         final boolean skipJava = args.containsKey("skip-java");
         final boolean skipNative = args.containsKey("skip-native");
         final boolean skipNativeAgents = args.containsKey("skip-native-agents");
+        final boolean disableDebuginfoStripping = args.containsKey("disable-debuginfo-stripping");
 
         final String archiveSuffix = optional("archive-suffix", args);
 
@@ -580,6 +584,7 @@ class Options
             , vendor
             , vendorUrl
             , mavenDeployLocal
+            , disableDebuginfoStripping
         );
     }
 
@@ -1176,6 +1181,7 @@ class Mx
                     , "--native-images=lib:native-image-agent,lib:native-image-diagnostics-agent"
                     , "--components=ni"
                     , "--exclude-components=nju,svmnfi,svml,tflm"
+                    , options.disableDebuginfoStripping ? "--disable-debuginfo-stripping" : ""
                     , "build"
                 )
                 , buildArgs.args


### PR DESCRIPTION
Cherry picked commits from https://github.com/graalvm/mandrel-packaging/pull/388 to `24.0`

- Introduce `--disable-debuginfo-stripping` option
- [CI] Fetch compatible mx version instead of `master`
- [CI] Disable `--verbose` in CI runs, because it adds too much noise
