### PR TITLE
[23.1] Fix preview build

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -103,8 +103,19 @@ jobs:
         ${MANDREL_HOME}/bin/native-image HelloStrict
         ./hellostrict | tee native.txt
         diff java.txt native.txt
+        rm -f java.txt native.txt
         ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
         ${MANDREL_HOME}/bin/native-image --version
+        echo "
+        void main() {
+            System.out.println(\"Implicitly declared classes.\");
+        }
+        " > ImplicitClass.java
+        ${MANDREL_HOME}/bin/javac --enable-preview --release 21 ImplicitClass.java
+        ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
+        ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
+        ./implicitclass | tee native.txt
+        diff java.txt native.txt
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
@@ -194,8 +205,19 @@ jobs:
           ${MANDREL_HOME}/bin/native-image HelloStrict
           ./hellostrict | tee native.txt
           diff java.txt native.txt
+          rm -f java.txt native.txt
           ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
           ${MANDREL_HOME}/bin/native-image --version
+          echo "
+          void main() {
+              System.out.println(\"Implicitly declared classes.\");
+          }
+          " > ImplicitClass.java
+          ${MANDREL_HOME}/bin/javac --enable-preview --release 21 ImplicitClass.java
+          ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
+          ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
+          ./implicitclass | tee native.txt
+          diff java.txt native.txt
       - name: Upload Mandrel build
         uses: actions/upload-artifact@v3
         with:
@@ -295,7 +317,23 @@ jobs:
           Write-Host $DIFF
           exit 1
         }
+        & Remove-Item -Path java.txt -Force
+        & Remove-Item -Path native.txt -Force
         & ${MANDREL_HOME}/bin/native-image.cmd --macro:native-image-launcher
+        Set-Content -Path 'ImplicitClass.java' -Value "
+        void main() {
+            System.out.println(`"Implicitly declared classes.`");
+        }
+        "
+        & $MANDREL_HOME\bin\javac --enable-preview --release 21 ImplicitClass.java
+        & $MANDREL_HOME\bin\java --enable-preview ImplicitClass | Set-Content java.txt
+        & $MANDREL_HOME\bin\native-image.cmd --enable-preview ImplicitClass
+        & ./implicitclass | Set-Content native.txt
+        $DIFF=(Compare-Object -CaseSensitive (Get-Content java.txt) (Get-Content native.txt))
+        if ($DIFF -ne $null) {
+          Write-Host $DIFF
+          exit 1
+        }
     - name: Rename mandrel archive
       shell: bash
       run: |
@@ -396,8 +434,19 @@ jobs:
         ${MANDREL_HOME}/bin/native-image HelloStrict
         ./hellostrict | tee native.txt
         diff java.txt native.txt
+        rm -f java.txt native.txt
         ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
         ${MANDREL_HOME}/bin/native-image --version
+        echo "
+        void main() {
+            System.out.println(\"Implicitly declared classes.\");
+        }
+        " > ImplicitClass.java
+        ${MANDREL_HOME}/bin/javac --enable-preview --release 21 ImplicitClass.java
+        ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
+        ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
+        ./implicitclass | tee native.txt
+        diff java.txt native.txt
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:

--- a/build.java
+++ b/build.java
@@ -132,6 +132,10 @@ public class build
             FileSystem.copy(mandrelRepo.resolve(
                 Path.of("sdk", "mxbuild", PLATFORM, IS_WINDOWS ? "native-image.exe.image-bash" : "native-image.image-bash",
                     IS_WINDOWS ? "native-image.cmd" : "native-image")), nativeImage);
+            logger.debugf("Copy svm-preview...");
+            final Path svmForeign = mandrelJavaHome.resolve(Path.of("lib", "svm-preview", "builder", "svm-foreign.jar"));
+            FileSystem.copy(mandrelRepo.resolve(
+                Path.of("substratevm", "mxbuild", JDK_VERSION, "dists", JDK_VERSION, "svm-foreign.jar")), svmForeign);
         }
 
         if (!options.skipNative)
@@ -871,7 +875,7 @@ class Mx
         Pattern.compile("\"version\"\\s*:\\s*\"([0-9.]*)\"");
 
     static final List<BuildArgs> BUILD_JAVA_STEPS = List.of(
-        BuildArgs.of("--no-native", "--dependencies", "SVM,GRAAL_SDK,SVM_DRIVER,SVM_AGENT,SVM_DIAGNOSTICS_AGENT")
+        BuildArgs.of("--no-native", "--dependencies", "SVM,SVM_FOREIGN,GRAAL_SDK,SVM_DRIVER,SVM_AGENT,SVM_DIAGNOSTICS_AGENT")
         , BuildArgs.of("--only",
             build.IS_WINDOWS ?
                 "native-image.exe.image-bash," +


### PR DESCRIPTION
Currently using `--enable-preview` is broken for Mandrel builds, since it doesn't install `svm-foreign.jar` in the right directory. This patch adds the relevant dependency (`SVM_FOREIGN`) and then installs it.

Closes: https://github.com/graalvm/mandrel/issues/658