### PR TITLE
[24.0] Fix preview build

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -108,8 +108,19 @@ jobs:
         ${MANDREL_HOME}/bin/native-image HelloStrict
         ./hellostrict | tee native.txt
         diff java.txt native.txt
+        rm -f java.txt native.txt
         ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
         ${MANDREL_HOME}/bin/native-image --version
+        echo "
+        void main() {
+            System.out.println(\"Implicitly declared classes.\");
+        }
+        " > ImplicitClass.java
+        ${MANDREL_HOME}/bin/javac --enable-preview --release 22 ImplicitClass.java
+        ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
+        ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
+        ./implicitclass | tee native.txt
+        diff java.txt native.txt
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
@@ -210,8 +221,19 @@ jobs:
           ${MANDREL_HOME}/bin/native-image HelloStrict
           ./hellostrict | tee native.txt
           diff java.txt native.txt
+          rm -f java.txt native.txt
           ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
           ${MANDREL_HOME}/bin/native-image --version
+          echo "
+          void main() {
+              System.out.println(\"Implicitly declared classes.\");
+          }
+          " > ImplicitClass.java
+          ${MANDREL_HOME}/bin/javac --enable-preview --release 22 ImplicitClass.java
+          ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
+          ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
+          ./implicitclass | tee native.txt
+          diff java.txt native.txt
       - name: Upload Mandrel build
         uses: actions/upload-artifact@v3
         with:
@@ -316,7 +338,23 @@ jobs:
           Write-Host $DIFF
           exit 1
         }
+        & Remove-Item -Path java.txt -Force
+        & Remove-Item -Path native.txt -Force
         & ${MANDREL_HOME}/bin/native-image.cmd --macro:native-image-launcher
+        Set-Content -Path 'ImplicitClass.java' -Value "
+        void main() {
+            System.out.println(`"Implicitly declared classes.`");
+        }
+        "
+        & $MANDREL_HOME\bin\javac --enable-preview --release 22 ImplicitClass.java
+        & $MANDREL_HOME\bin\java --enable-preview ImplicitClass | Set-Content java.txt
+        & $MANDREL_HOME\bin\native-image.cmd --enable-preview ImplicitClass
+        & ./implicitclass | Set-Content native.txt
+        $DIFF=(Compare-Object -CaseSensitive (Get-Content java.txt) (Get-Content native.txt))
+        if ($DIFF -ne $null) {
+          Write-Host $DIFF
+          exit 1
+        }
     - name: Rename mandrel archive
       shell: bash
       run: |
@@ -422,8 +460,19 @@ jobs:
         ${MANDREL_HOME}/bin/native-image HelloStrict
         ./hellostrict | tee native.txt
         diff java.txt native.txt
+        rm -f java.txt native.txt
         ${MANDREL_HOME}/bin/native-image --macro:native-image-launcher
         ${MANDREL_HOME}/bin/native-image --version
+        echo "
+        void main() {
+            System.out.println(\"Implicitly declared classes.\");
+        }
+        " > ImplicitClass.java
+        ${MANDREL_HOME}/bin/javac --enable-preview --release 22 ImplicitClass.java
+        ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
+        ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
+        ./implicitclass | tee native.txt
+        diff java.txt native.txt
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:

--- a/build.java
+++ b/build.java
@@ -138,6 +138,10 @@ public class build
                 FileSystem.copy(mandrelRepo.resolve(
                     Path.of("sdk", "mxbuild", PLATFORM, "native-image.exe.image-bash", "native-image.export-list")), nativeImageExport);
             }
+            logger.debugf("Copy svm-preview...");
+            final Path svmForeign = mandrelJavaHome.resolve(Path.of("lib", "svm-preview", "builder", "svm-foreign.jar"));
+            FileSystem.copy(mandrelRepo.resolve(
+                Path.of("substratevm", "mxbuild", JDK_VERSION, "dists", JDK_VERSION, "svm-foreign.jar")), svmForeign);
         }
 
         if (!options.skipNative)
@@ -877,7 +881,7 @@ class Mx
         Pattern.compile("\"version\"\\s*:\\s*\"([0-9.]*)\"");
 
     static final List<BuildArgs> BUILD_JAVA_STEPS = List.of(
-        BuildArgs.of("--no-native", "--dependencies", "SVM,GRAAL_SDK,SVM_DRIVER,SVM_AGENT,SVM_DIAGNOSTICS_AGENT")
+        BuildArgs.of("--no-native", "--dependencies", "SVM,SVM_FOREIGN,GRAAL_SDK,SVM_DRIVER,SVM_AGENT,SVM_DIAGNOSTICS_AGENT")
         , BuildArgs.of("--only",
             build.IS_WINDOWS ?
                 "native-image.exe.image-bash," +


### PR DESCRIPTION
Same as https://github.com/graalvm/mandrel-packaging/pull/391 but targeting 24.0/JDK 22. Replaced `--release 21` with `--release 22` in smoke tests.