### PR TITLE
[JDK 22/23] Fix installation/copy of svm-foreign.jar

### DIFF
--- a/build.java
+++ b/build.java
@@ -138,10 +138,6 @@ public class build
                 FileSystem.copy(mandrelRepo.resolve(
                     Path.of("sdk", "mxbuild", PLATFORM, "native-image.exe.image-bash", "native-image.export-list")), nativeImageExport);
             }
-            logger.debugf("Copy svm-preview...");
-            final Path svmForeign = mandrelJavaHome.resolve(Path.of("lib", "svm-preview", "builder", "svm-foreign.jar"));
-            FileSystem.copy(mandrelRepo.resolve(
-                Path.of("substratevm", "mxbuild", JDK_VERSION, "dists", JDK_VERSION, "svm-foreign.jar")), svmForeign);
         }
 
         if (!options.skipNative)
@@ -975,7 +971,9 @@ class Mx
             new SimpleEntry<>("org.graalvm.nativeimage:svm-diagnostics-agent.jar",
                 new Path[]{substrateDistPath.resolve("svm-diagnostics-agent.jar"), Path.of("lib", "graalvm", "svm-diagnostics-agent.jar")}),
             new SimpleEntry<>("org.graalvm.nativeimage:svm-configure.jar",
-                new Path[]{substrateDistPath.resolve("svm-configure.jar"), Path.of("lib", "graalvm", "svm-configure.jar")})
+                new Path[]{substrateDistPath.resolve("svm-configure.jar"), Path.of("lib", "graalvm", "svm-configure.jar")}),
+            new SimpleEntry<>("org.graalvm.nativeimage:svm-foreign.jar",
+                new Path[]{substrateDistPath.resolve("svm-foreign.jar"), Path.of("lib", "svm", "builder", "svm-foreign.jar")})
         );
 
         macroPaths = Map.ofEntries(


### PR DESCRIPTION
Same as #399 but for the 24.0 (JDK 22) branch. The difference being that the copy finds the right `svm-foreign.jar`, but still copies it to the wrong location. The finding-the-wrong source to copy from is a master only bug.

Thoughts?