### PR TITLE
[23.1] Install *src.zip for svm-foreign.jar

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -173,6 +173,12 @@ jobs:
           mkdir -p ${JAVA_HOME}
           tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
           tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+          # work-around for https://github.com/adoptium/temurin-build/issues/3602
+          pushd ${MAC_JAVA_HOME}
+          if [ -e lib/static/darwin-arm64 ]; then
+            mv lib/static/darwin-arm64 lib/static/darwin-amd64
+          fi
+          popd
           echo ${MAC_JAVA_HOME}
           ${MAC_JAVA_HOME}/bin/java --version
       - name: Build Mandrel JDK

--- a/build.java
+++ b/build.java
@@ -132,10 +132,6 @@ public class build
             FileSystem.copy(mandrelRepo.resolve(
                 Path.of("sdk", "mxbuild", PLATFORM, IS_WINDOWS ? "native-image.exe.image-bash" : "native-image.image-bash",
                     IS_WINDOWS ? "native-image.cmd" : "native-image")), nativeImage);
-            logger.debugf("Copy svm-preview...");
-            final Path svmForeign = mandrelJavaHome.resolve(Path.of("lib", "svm-preview", "builder", "svm-foreign.jar"));
-            FileSystem.copy(mandrelRepo.resolve(
-                Path.of("substratevm", "mxbuild", JDK_VERSION, "dists", JDK_VERSION, "svm-foreign.jar")), svmForeign);
         }
 
         if (!options.skipNative)
@@ -969,7 +965,9 @@ class Mx
             new SimpleEntry<>("org.graalvm.nativeimage:svm-diagnostics-agent.jar",
                 new Path[]{substrateDistPath.resolve("svm-diagnostics-agent.jar"), Path.of("lib", "graalvm", "svm-diagnostics-agent.jar")}),
             new SimpleEntry<>("org.graalvm.nativeimage:svm-configure.jar",
-                new Path[]{substrateDistPath.resolve("svm-configure.jar"), Path.of("lib", "graalvm", "svm-configure.jar")})
+                new Path[]{substrateDistPath.resolve("svm-configure.jar"), Path.of("lib", "graalvm", "svm-configure.jar")}),
+            new SimpleEntry<>("org.graalvm.nativeimage:svm-foreign.jar",
+                new Path[]{substrateDistPath.resolve("svm-foreign.jar"), Path.of("lib", "svm-preview", "builder", "svm-foreign.jar")})
         );
 
         macroPaths = Map.ofEntries(


### PR DESCRIPTION
Use a similar approach to `24.0` and `24.1` for installing `svm-foreign.jar`. This has
the advantage that the `src.zip` file gets installed as well.