### PR TITLE
Add SVM_FOREIGN to maven deploy steps

### DIFF
--- a/build.java
+++ b/build.java
@@ -996,6 +996,7 @@ class Mx
                 "SVM_AGENT," +
                 "SVM_DIAGNOSTICS_AGENT," +
                 "SVM_CONFIGURE," +
+                "SVM_FOREIGN," +
                 "MANDREL_PACKAGING_WRAPPER")
     );
 


### PR DESCRIPTION
This is needed to deploy the svm-foreign artefact to a maven repo needed for the split java build.

This targets `23.1`, but I'll forward-port this to `24.0` and `24.1` as needed once it's in `23.1`.