### PR TITLE
[CI] Set PYTHONIOENCODING to utf-8 to make mx happy

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -18,6 +18,7 @@ env:
   # This ought to be a valid version parseable by Version.parse()
   MANDREL_VERSION: 10.9.8.7-dev
   MX_PYTHON: python3
+  PYTHONIOENCODING: utf-8
 
 # The following aims to reduce CI CPU cycles by:
 # 1. Cancelling any previous builds of this PR when pushing new changes to it


### PR DESCRIPTION
Starting with mx 7.24.0, mx checks if the stdout encoding is set to
unicode.

See
https://github.com/graalvm/mx/commit/b6625a410340c52c79d3006fd0fbcaf16f1aa608
