### PR TITLE
Support 4-digit mx versions

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -66,10 +66,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 23 with static libs
+    - name: Get latest OpenJDK 24 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/24/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/24/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -84,12 +84,12 @@ jobs:
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java23-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java23-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java24-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java24-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java23-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java24-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -117,7 +117,7 @@ jobs:
             System.out.println(\"Implicitly declared classes.\");
         }
         " > ImplicitClass.java
-        ${MANDREL_HOME}/bin/javac --enable-preview --release 23 ImplicitClass.java
+        ${MANDREL_HOME}/bin/javac --enable-preview --release 24 ImplicitClass.java
         ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
         ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
         ./implicitclass | tee native.txt
@@ -125,19 +125,19 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java23-linux-amd64-test-build
-        path: mandrel-java23-linux-amd64.tar.gz
+        name: mandrel-java24-linux-amd64-test-build
+        path: mandrel-java24-linux-amd64.tar.gz
     - name: Build Mandrel JDK with tarxz suffix
       run: |
         ${JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tarxz --skip-clean --skip-java --skip-native
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java23-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
-        mv ${ARCHIVE_NAME} mandrel-java23-linux-amd64.tarxz
+        export ARCHIVE_NAME="mandrel-java24-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tarxz"
+        mv ${ARCHIVE_NAME} mandrel-java24-linux-amd64.tarxz
     - name: Upload tarxz Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java23-linux-amd64-test-build-tarxz
-        path: mandrel-java23-linux-amd64.tarxz
+        name: mandrel-java24-linux-amd64-test-build-tarxz
+        path: mandrel-java24-linux-amd64.tarxz
 
   build-and-test-on-mac:
     name: ${{ matrix.os }} Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -179,12 +179,12 @@ jobs:
           export ARCH=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]' | sed 's/arm64/aarch64/')
           echo "ARCH=${ARCH}"
           echo "ARCH=${ARCH}" >> "$GITHUB_OUTPUT"
-      - name: Get latest OpenJDK 23 with static libs
+      - name: Get latest OpenJDK 24 with static libs
         env:
           ARCH: ${{ steps.arch.outputs.ARCH }}
         run: |
-          curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/mac/${ARCH}/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-          curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/mac/${ARCH}/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+          curl -sL https://api.adoptium.net/v3/binary/latest/24/ea/mac/${ARCH}/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+          curl -sL https://api.adoptium.net/v3/binary/latest/24/ea/mac/${ARCH}/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
           mkdir -p ${JAVA_HOME}
           tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
           tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -215,13 +215,13 @@ jobs:
           ${MAC_JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
           export ARCH=$( echo ${ARCH} | sed 's/x64/amd64/' )
-          export ARCHIVE_NAME="mandrel-java23-darwin-${ARCH}-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-          mv ${ARCHIVE_NAME} mandrel-java23-darwin-${ARCH}.tar.gz
+          export ARCHIVE_NAME="mandrel-java24-darwin-${ARCH}-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+          mv ${ARCHIVE_NAME} mandrel-java24-darwin-${ARCH}.tar.gz
           echo "ARCH=${ARCH}" >> "$GITHUB_OUTPUT"
       - name: Smoke tests
         run: |
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-          export MANDREL_HOME=${PWD}/mandrel-java23-${MANDREL_VERSION_UNTIL_SPACE}/Contents/Home
+          export MANDREL_HOME=${PWD}/mandrel-java24-${MANDREL_VERSION_UNTIL_SPACE}/Contents/Home
           ${MANDREL_HOME}/bin/native-image --version
           ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
           echo "
@@ -249,7 +249,7 @@ jobs:
               System.out.println(\"Implicitly declared classes.\");
           }
           " > ImplicitClass.java
-          ${MANDREL_HOME}/bin/javac --enable-preview --release 23 ImplicitClass.java
+          ${MANDREL_HOME}/bin/javac --enable-preview --release 24 ImplicitClass.java
           ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
           ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
           ./implicitclass | tee native.txt
@@ -259,8 +259,8 @@ jobs:
         env:
           ARCH: ${{ steps.build.outputs.ARCH }}
         with:
-          name: mandrel-java23-darwin-${ARCH}-test-build
-          path: mandrel-java23-darwin-${ARCH}.tar.gz
+          name: mandrel-java24-darwin-${ARCH}-test-build
+          path: mandrel-java24-darwin-${ARCH}.tar.gz
 
   build-and-test-on-windows:
     name: Windows Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -295,13 +295,13 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 23 with static libs
+    - name: Get latest OpenJDK 24 with static libs
       run: |
         $wc = New-Object System.Net.WebClient
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/23/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/24/ea/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
         Expand-Archive "$Env:temp\jdk.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/23/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/24/ea/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
         Expand-Archive "$Env:temp\jdk-staticlibs.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\jdk-*\lib\static" -Destination $Env:JAVA_HOME\lib\
         Remove-Item -Recurse "$Env:temp\jdk-*"
@@ -333,7 +333,7 @@ jobs:
           }
         }
         $MANDREL_VERSION_UNTIL_SPACE=$Env:MANDREL_VERSION -replace "^(.*?) .*$","`$1"
-        $MANDREL_HOME=".\mandrel-java23-$MANDREL_VERSION_UNTIL_SPACE"
+        $MANDREL_HOME=".\mandrel-java24-$MANDREL_VERSION_UNTIL_SPACE"
         $VERSION=(& $MANDREL_HOME\bin\native-image.cmd --version)
         Write-Host $VERSION
         if ("$VERSION" -NotMatch "$Env:MANDREL_VERSION") {
@@ -368,7 +368,7 @@ jobs:
             System.out.println(`"Implicitly declared classes.`");
         }
         "
-        & $MANDREL_HOME\bin\javac --enable-preview --release 23 ImplicitClass.java
+        & $MANDREL_HOME\bin\javac --enable-preview --release 24 ImplicitClass.java
         & $MANDREL_HOME\bin\java --enable-preview ImplicitClass | Set-Content java.txt
         & $MANDREL_HOME\bin\native-image.cmd --enable-preview ImplicitClass
         & ./implicitclass | Set-Content native.txt
@@ -381,13 +381,13 @@ jobs:
       shell: bash
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java23-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
-        mv ${ARCHIVE_NAME} mandrel-java23-windows-amd64.zip
+        export ARCHIVE_NAME="mandrel-java24-windows-amd64-${MANDREL_VERSION_UNTIL_SPACE}.zip"
+        mv ${ARCHIVE_NAME} mandrel-java24-windows-amd64.zip
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java23-windows-amd64-test-build
-        path: mandrel-java23-windows-amd64.zip
+        name: mandrel-java24-windows-amd64-test-build
+        path: mandrel-java24-windows-amd64.zip
 
   build-and-test-2-step:
     name: 2-step Linux Build and test ${{ matrix.mandrel-ref }} branch/tag
@@ -421,10 +421,10 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
-    - name: Get latest OpenJDK 23 with static libs
+    - name: Get latest OpenJDK 24 with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/24/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/24/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -457,12 +457,12 @@ jobs:
         --skip-java \
         --archive-suffix tar.gz
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export ARCHIVE_NAME="mandrel-java23-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-        mv ${ARCHIVE_NAME} mandrel-java23-linux-amd64.tar.gz
+        export ARCHIVE_NAME="mandrel-java24-linux-amd64-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+        mv ${ARCHIVE_NAME} mandrel-java24-linux-amd64.tar.gz
     - name: Smoke tests
       run: |
         export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
-        export MANDREL_HOME=${PWD}/mandrel-java23-${MANDREL_VERSION_UNTIL_SPACE}
+        export MANDREL_HOME=${PWD}/mandrel-java24-${MANDREL_VERSION_UNTIL_SPACE}
         ${MANDREL_HOME}/bin/native-image --version
         ${MANDREL_HOME}/bin/native-image --version | grep "${MANDREL_VERSION}"
         echo "
@@ -490,7 +490,7 @@ jobs:
             System.out.println(\"Implicitly declared classes.\");
         }
         " > ImplicitClass.java
-        ${MANDREL_HOME}/bin/javac --enable-preview --release 23 ImplicitClass.java
+        ${MANDREL_HOME}/bin/javac --enable-preview --release 24 ImplicitClass.java
         ${MANDREL_HOME}/bin/java --enable-preview ImplicitClass | tee java.txt
         ${MANDREL_HOME}/bin/native-image --enable-preview ImplicitClass
         ./implicitclass | tee native.txt
@@ -498,5 +498,5 @@ jobs:
     - name: Upload Mandrel build
       uses: actions/upload-artifact@v3
       with:
-        name: mandrel-java23-linux-amd64-2step-test-build
-        path: mandrel-java23-linux-amd64.tar.gz
+        name: mandrel-java24-linux-amd64-2step-test-build
+        path: mandrel-java24-linux-amd64.tar.gz

--- a/build.java
+++ b/build.java
@@ -1527,18 +1527,24 @@ class MxVersion implements Comparable<MxVersion>
     final int major;
     final int minor;
     final int patch;
+    final int build;
     static final MxVersion mx5_313_0 = new MxVersion("5.313.0");
 
     MxVersion(String version)
     {
         String[] split = version.split("\\.");
-        if (split.length != 3)
+        if (split.length < 3 || split.length > 4)
         {
-            throw new IllegalArgumentException("Version should be of the form MAJOR.MINOR.PATCH not " + version);
+            throw new IllegalArgumentException("Version should be of the form MAJOR.MINOR.PATCH[.BUILD] not " + version);
         }
         major = Integer.parseInt(split[0]);
         minor = Integer.parseInt(split[1]);
         patch = Integer.parseInt(split[2]);
+        if (split.length == 4) {
+            build = Integer.parseInt(split[3]);
+        } else {
+            build = 0;
+        }
     }
 
     @Override
@@ -1554,7 +1560,12 @@ class MxVersion implements Comparable<MxVersion>
         {
             return result;
         }
-        return patch - other.patch;
+        result = patch - other.patch;
+        if (result != 0)
+        {
+            return result;
+        }
+        return build - other.build;
     }
 }
 


### PR DESCRIPTION
The assumption that mx versions follow the MAJOR.MINOR.PATCH versioning
seems to not always hold. E.g. the following releases include an
additional 4th number:

* 5.275.7.1
* 6.9.1.1
* 7.4.1.1

Resolves https://github.com/graalvm/mandrel/pull/771#issuecomment-2232778931

It will need to be backported at least to `24.0`