### PR TITLE
Exclude svmt (Truffle Runtime SVM) component as well

### DIFF
--- a/build.java
+++ b/build.java
@@ -1209,7 +1209,7 @@ class Mx
                     , javaHome.toString()
                     , "--native-images=lib:native-image-agent,lib:native-image-diagnostics-agent"
                     , "--components=ni"
-                    , "--exclude-components=nju,svmnfi,svml,tflm"
+                    , "--exclude-components=nju,svmnfi,svml,tflm,svmt"
                     , options.disableDebuginfoStripping ? "--disable-debuginfo-stripping" : ""
                     , "build"
                 )


### PR DESCRIPTION
Since we explicitly don't build and ship core truffle packages there is
no point in including this component.

Required by https://github.com/oracle/graal/pull/9957 to resolve
https://github.com/graalvm/mandrel/issues/805 but makes sense to merge
regardless of whether https://github.com/graalvm/mandrel/issues/805 will
end up being accepted or not.
