### PR TITLE
Use option --jmods-dir NO_JMODS for Mandrel based on JDK 24

### DIFF
--- a/build.java
+++ b/build.java
@@ -1203,6 +1203,7 @@ class Mx
                 List.of(
                     mx.toString()
                     , options.verbose ? "-V" : ""
+                    , "--jmods-dir", "NO_JMODS"
                     , "--trust-http"
                     , "--no-jlinking"
                     , "--java-home"


### PR DESCRIPTION
This change is contingent on two dependency PRs:

- `mx`: https://github.com/graalvm/mx/pull/287
- `oracle/graal`: https://github.com/oracle/graal/pull/10161

Closes: https://github.com/graalvm/mandrel/issues/808