### PR TITLE
[24.2] Backport: Align artifact name with what GraalVM CE generates in its releases

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -215,8 +215,8 @@ jobs:
           ${MAC_JAVA_HOME}/bin/java -ea build.java --mx-home ${MX_HOME} --mandrel-repo ${MANDREL_REPO} --mandrel-version "${MANDREL_VERSION}" --archive-suffix tar.gz
           export MANDREL_VERSION_UNTIL_SPACE="$( echo ${MANDREL_VERSION} | sed -e 's/\([^ ]*\).*/\1/;t' )"
           export ARCH=$( echo ${ARCH} | sed 's/x64/amd64/' )
-          export ARCHIVE_NAME="mandrel-java24-darwin-${ARCH}-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
-          mv ${ARCHIVE_NAME} mandrel-java24-darwin-${ARCH}.tar.gz
+          export ARCHIVE_NAME="mandrel-java24-macos-${ARCH}-${MANDREL_VERSION_UNTIL_SPACE}.tar.gz"
+          mv ${ARCHIVE_NAME} mandrel-java24-macos-${ARCH}.tar.gz
           echo "ARCH=${ARCH}" >> "$GITHUB_OUTPUT"
       - name: Smoke tests
         run: |
@@ -259,8 +259,8 @@ jobs:
         env:
           ARCH: ${{ steps.build.outputs.ARCH }}
         with:
-          name: mandrel-java24-darwin-${ARCH}-test-build
-          path: mandrel-java24-darwin-${ARCH}.tar.gz
+          name: mandrel-java24-macos-${ARCH}-test-build
+          path: mandrel-java24-macos-${ARCH}.tar.gz
 
   build-and-test-on-windows:
     name: Windows Build and test ${{ matrix.mandrel-ref }} branch/tag

--- a/build.java
+++ b/build.java
@@ -255,7 +255,7 @@ public class build
         if (options.archiveSuffix != null)
         {
             int javaMajor = Runtime.version().feature();
-            String archiveName = "mandrel-java" + javaMajor + "-" + PLATFORM + "-" + mandrelVersionUntilSpace + "." + options.archiveSuffix;
+            String archiveName = "mandrel-java" + javaMajor + "-" + PLATFORM.replace("darwin", "macos") + "-" + mandrelVersionUntilSpace + "." + options.archiveSuffix;
             logger.info("Creating Archive " + archiveName);
             createArchive(fs, os, mandrelHome, archiveName);
         }

--- a/jenkins/jobs/builds/Constants.groovy
+++ b/jenkins/jobs/builds/Constants.groovy
@@ -78,7 +78,8 @@ class Constants {
         mv ${JAVA_HOME}/lib/static/darwin-arm64 ${JAVA_HOME}/lib/static/darwin-aarch64
     fi
     ./jenkins/jobs/scripts/mandrel_linux_build.sh
-    # We align to what GraalVM CE calls its releases:
+    # We align to what GraalVM CE calls its releases
+    # this is no longer needed as of mandrel-packaging 24.2, but we keep it for backwards compatibility:
     for m in mandrel-*.tar.gz*;do n=$(echo $m | sed 's/darwin-aarch64/macos-aarch64/g'); mv $m $n;done
     find .
     '''


### PR DESCRIPTION
Partial backport of https://github.com/graalvm/mandrel-packaging/pull/467. The difference is that it doesn't update the JDK version to 25 in the CI.