### PR TITLE
Fix mandrel build with JDK 25+18

### DIFF
--- a/.github/workflows/buildJDK.yml
+++ b/.github/workflows/buildJDK.yml
@@ -22,7 +22,7 @@ env:
   TEMURIN_API_URL_LATEST: https://api.adoptium.net/v3/binary/latest/25/ea
   # Use this to 'pin' to a specific JDK build. The respective
   # release needs to exist.
-  TEMURIN_PINNED_RELEASE: jdk-25%2B14-ea-beta
+  #TEMURIN_PINNED_RELEASE: jdk-25%2B14-ea-beta
 
 # The following aims to reduce CI CPU cycles by:
 # 1. Cancelling any previous builds of this PR when pushing new changes to it

--- a/build.java
+++ b/build.java
@@ -992,6 +992,8 @@ class Mx
                 new Path[]{compilerDistPath.resolve("graal.jar"), Path.of("lib", "jvmci", "graal.jar")}),
             new SimpleEntry<>("org.graalvm.nativeimage:objectfile.jar",
                 new Path[]{substrateDistPath.resolve("objectfile.jar"), Path.of("lib", "svm", "builder", "objectfile.jar")}),
+            new SimpleEntry<>("org.graalvm.nativeimage:svm-capnproto-runtime.jar",
+                new Path[]{substrateDistPath.resolve("svm-capnproto-runtime.jar"), Path.of("lib", "svm", "builder", "svm-capnproto-runtime.jar")}),
             new SimpleEntry<>("org.graalvm.nativeimage:svm-driver.jar",
                 new Path[]{substrateDistPath.resolve("svm-driver.jar"), Path.of("lib", "graalvm", "svm-driver.jar")}),
             new SimpleEntry<>("org.graalvm.nativeimage:jvmti-agent-base.jar",


### PR DESCRIPTION
This adds the new required dependency module,
`org.graalvm.nativeimage.shaded.capnproto`, which is already built.
Be sure to copy the required jar to the `lib/svm/builder` directory.

Closes: https://github.com/graalvm/mandrel/issues/838